### PR TITLE
Sending raw HttpEntities to Get or Delete request like for JSON payloads.

### DIFF
--- a/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
@@ -67,7 +67,6 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.SyncBasicHttpContext;
-import org.json.JSONObject;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
@@ -40,9 +40,7 @@ import org.apache.http.client.CookieStore;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.RedirectHandler;
-import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -69,6 +67,7 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.SyncBasicHttpContext;
+import org.json.JSONObject;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -901,6 +900,23 @@ public class AsyncHttpClient {
                 context);
     }
 
+    /**
+     * Perform a HTTP GET request and track the Android Context which initiated the request.
+     *
+     * @param context         the Android Context which initiated the request.
+     * @param url             the URL to send the request to.
+     * @param entity          a raw {@link org.apache.http.HttpEntity} to send with the request, for
+     *                        example, use this to send string/json/xml payloads to a server by
+     *                        passing a {@link org.apache.http.entity.StringEntity}.
+     * @param contentType     the content type of the payload you are sending, for example
+     *                        application/json if sending a json payload.
+     * @param responseHandler the response ha   ndler instance that should handle the response.
+     * @return RequestHandle of future request process
+     */
+    public RequestHandle get(Context context, String url, HttpEntity entity, String contentType, ResponseHandlerInterface responseHandler) {
+        return sendRequest(httpClient, httpContext, addEntityToRequestBase(new HttpGet(URI.create(url).normalize()), entity), contentType, responseHandler, context);
+    }
+
     // [-] HTTP GET
     // [+] HTTP POST
 
@@ -1204,6 +1220,23 @@ public class AsyncHttpClient {
         HttpDelete httpDelete = new HttpDelete(getUrlWithQueryString(isUrlEncodingEnabled, url, params));
         if (headers != null) httpDelete.setHeaders(headers);
         return sendRequest(httpClient, httpContext, httpDelete, null, responseHandler, context);
+    }
+
+    /**
+     * Perform a HTTP DELETE request and track the Android Context which initiated the request.
+     *
+     * @param context         the Android Context which initiated the request.
+     * @param url             the URL to send the request to.
+     * @param entity          a raw {@link org.apache.http.HttpEntity} to send with the request, for
+     *                        example, use this to send string/json/xml payloads to a server by
+     *                        passing a {@link org.apache.http.entity.StringEntity}.
+     * @param contentType     the content type of the payload you are sending, for example
+     *                        application/json if sending a json payload.
+     * @param responseHandler the response ha   ndler instance that should handle the response.
+     * @return RequestHandle of future request process
+     */
+    public RequestHandle delete(Context context, String url, HttpEntity entity, String contentType, ResponseHandlerInterface responseHandler) {
+        return sendRequest(httpClient, httpContext, addEntityToRequestBase(new HttpDelete(URI.create(url).normalize()), entity), contentType, responseHandler, context);
     }
 
     // [-] HTTP DELETE

--- a/library/src/main/java/com/loopj/android/http/HttpDelete.java
+++ b/library/src/main/java/com/loopj/android/http/HttpDelete.java
@@ -24,7 +24,8 @@ import java.net.URI;
 
 /**
  * The current Android (API level 21) bundled version of the Apache Http Client does not implement
- * the HTTP PATCH method. Until the Android version is updated this can serve in it's stead. 
+ * a HttpEntityEnclosingRequestBase type of HTTP DELETE method.
+ * Until the Android version is updated this can serve in it's stead.
  * This implementation can and should go away when the official solution arrives.
  */
 public final class HttpDelete extends HttpEntityEnclosingRequestBase {

--- a/library/src/main/java/com/loopj/android/http/HttpDelete.java
+++ b/library/src/main/java/com/loopj/android/http/HttpDelete.java
@@ -1,0 +1,54 @@
+/*
+    Android Asynchronous Http Client
+    Copyright (c) 2011 James Smith <james@loopj.com>
+    http://loopj.com
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.loopj.android.http;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
+
+/**
+ * The current Android (API level 21) bundled version of the Apache Http Client does not implement
+ * the HTTP PATCH method. Until the Android version is updated this can serve in it's stead. 
+ * This implementation can and should go away when the official solution arrives.
+ */
+public final class HttpDelete extends HttpEntityEnclosingRequestBase {
+    public final static String METHOD_NAME = "DELETE";
+
+    public HttpDelete() {
+        super();
+    }
+
+    public HttpDelete(final URI uri) {
+        super();
+        setURI(uri);
+    }
+
+    /**
+     * @throws IllegalArgumentException if the uri is invalid.
+    */
+    public HttpDelete(final String uri) {
+            super();
+            setURI(URI.create(uri));
+    }
+
+    @Override
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+}

--- a/library/src/main/java/com/loopj/android/http/HttpGet.java
+++ b/library/src/main/java/com/loopj/android/http/HttpGet.java
@@ -1,0 +1,55 @@
+/*
+    Android Asynchronous Http Client
+    Copyright (c) 2011 James Smith <james@loopj.com>
+    http://loopj.com
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.loopj.android.http;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+
+import java.net.URI;
+
+/**
+ * The current Android (API level 21) bundled version of the Apache Http Client does not implement
+ * the HTTP PATCH method. Until the Android version is updated this can serve in it's stead. 
+ * This implementation can and should go away when the official solution arrives.
+ */
+public final class HttpGet extends HttpEntityEnclosingRequestBase {
+
+    public final static String METHOD_NAME = "GET";
+
+    public HttpGet() {
+        super();
+    }
+
+    public HttpGet(final URI uri) {
+        super();
+        setURI(uri);
+    }
+
+    /**
+     * @throws IllegalArgumentException if the uri is invalid.
+    */
+    public HttpGet(final String uri) {
+            super();
+            setURI(URI.create(uri));
+    }
+
+    @Override
+    public String getMethod() {
+        return METHOD_NAME;
+    }
+}

--- a/library/src/main/java/com/loopj/android/http/HttpGet.java
+++ b/library/src/main/java/com/loopj/android/http/HttpGet.java
@@ -24,7 +24,8 @@ import java.net.URI;
 
 /**
  * The current Android (API level 21) bundled version of the Apache Http Client does not implement
- * the HTTP PATCH method. Until the Android version is updated this can serve in it's stead. 
+ * a HttpEntityEnclosingRequestBase type of HTTP GET method.
+ * Until the Android version is updated this can serve in it's stead.
  * This implementation can and should go away when the official solution arrives.
  */
 public final class HttpGet extends HttpEntityEnclosingRequestBase {


### PR DESCRIPTION
This is the implementation of HTTP GET and DELETE request calls synonymous to 
```
public RequestHandle post(Context context, String url, Header[] headers, HttpEntity entity, String contentType,
                              ResponseHandlerInterface responseHandler) {
}
```
It means to serve raw `HttpEntity` payloads to the get and delete requests if the queries can handle one.
Doing this will allow to pass `JSON`, etc. via the entities.

For the same new `HttpDelete` and `HttpGet` are added which extends `HttpEntityEnclosingRequestBase` to add the supplied entities to the request base.
This will help in sending our own `Content-Type` with the entities instead of `application/x-www-form-urlencoded`