### PR TITLE
add disk Cache

### DIFF
--- a/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
@@ -14,7 +14,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.loopj.android.http;
 
@@ -70,6 +70,7 @@ import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.SyncBasicHttpContext;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -89,1424 +90,1933 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.zip.GZIPInputStream;
 
-
 /**
- * The AsyncHttpClient can be used to make asynchronous GET, POST, PUT and DELETE HTTP requests in
- * your Android applications. Requests can be made with additional parameters by passing a {@link
- * RequestParams} instance, and responses can be handled by passing an anonymously overridden {@link
- * ResponseHandlerInterface} instance. <p>&nbsp;</p> For example: <p>&nbsp;</p>
+ * The AsyncHttpClient can be used to make asynchronous GET, POST, PUT and
+ * DELETE HTTP requests in your Android applications. Requests can be made with
+ * additional parameters by passing a {@link RequestParams} instance, and
+ * responses can be handled by passing an anonymously overridden
+ * {@link ResponseHandlerInterface} instance.
+ * <p>
+ * &nbsp;
+ * </p>
+ * For example:
+ * <p>
+ * &nbsp;
+ * </p>
+ * 
  * <pre>
  * AsyncHttpClient client = new AsyncHttpClient();
- * client.get("http://www.google.com", new AsyncHttpResponseHandler() {
- *     &#064;Override
- *     public void onSuccess(int statusCode, Header[] headers, byte[] responseBody) {
- *          System.out.println(response);
- *     }
- *     &#064;Override
- *     public void onFailure(int statusCode, Header[] headers, byte[] responseBody, Throwable
- * error)
- * {
- *          error.printStackTrace(System.out);
- *     }
+ * client.get(&quot;http://www.google.com&quot;, new AsyncHttpResponseHandler() {
+ * 	&#064;Override
+ * 	public void onSuccess(int statusCode, Header[] headers, byte[] responseBody) {
+ * 		System.out.println(response);
+ * 	}
+ * 
+ * 	&#064;Override
+ * 	public void onFailure(int statusCode, Header[] headers,
+ * 			byte[] responseBody, Throwable error) {
+ * 		error.printStackTrace(System.out);
+ * 	}
  * });
  * </pre>
- *
+ * 
  * @see com.loopj.android.http.AsyncHttpResponseHandler
  * @see com.loopj.android.http.ResponseHandlerInterface
  * @see com.loopj.android.http.RequestParams
  */
 public class AsyncHttpClient {
 
-    public static final String LOG_TAG = "AsyncHttpClient";
-
-    public static final String HEADER_CONTENT_TYPE = "Content-Type";
-    public static final String HEADER_CONTENT_RANGE = "Content-Range";
-    public static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
-    public static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
-    public static final String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
-    public static final String ENCODING_GZIP = "gzip";
-
-    public static final int DEFAULT_MAX_CONNECTIONS = 10;
-    public static final int DEFAULT_SOCKET_TIMEOUT = 10 * 1000;
-    public static final int DEFAULT_MAX_RETRIES = 5;
-    public static final int DEFAULT_RETRY_SLEEP_TIME_MILLIS = 1500;
-    public static final int DEFAULT_SOCKET_BUFFER_SIZE = 8192;
-
-    private int maxConnections = DEFAULT_MAX_CONNECTIONS;
-    private int connectTimeout = DEFAULT_SOCKET_TIMEOUT;
-    private int responseTimeout = DEFAULT_SOCKET_TIMEOUT;
-
-    private final DefaultHttpClient httpClient;
-    private final HttpContext httpContext;
-    private ExecutorService threadPool;
-    private final Map<Context, List<RequestHandle>> requestMap;
-    private final Map<String, String> clientHeaderMap;
-    private boolean isUrlEncodingEnabled = true;
-
-    /**
-     * Creates a new AsyncHttpClient with default constructor arguments values
-     */
-    public AsyncHttpClient() {
-        this(false, 80, 443);
-    }
-
-    /**
-     * Creates a new AsyncHttpClient.
-     *
-     * @param httpPort non-standard HTTP-only port
-     */
-    public AsyncHttpClient(int httpPort) {
-        this(false, httpPort, 443);
-    }
-
-    /**
-     * Creates a new AsyncHttpClient.
-     *
-     * @param httpPort  non-standard HTTP-only port
-     * @param httpsPort non-standard HTTPS-only port
-     */
-    public AsyncHttpClient(int httpPort, int httpsPort) {
-        this(false, httpPort, httpsPort);
-    }
-
-    /**
-     * Creates new AsyncHttpClient using given params
-     *
-     * @param fixNoHttpResponseException Whether to fix issue or not, by omitting SSL verification
-     * @param httpPort                   HTTP port to be used, must be greater than 0
-     * @param httpsPort                  HTTPS port to be used, must be greater than 0
-     */
-    public AsyncHttpClient(boolean fixNoHttpResponseException, int httpPort, int httpsPort) {
-        this(getDefaultSchemeRegistry(fixNoHttpResponseException, httpPort, httpsPort));
-    }
-
-    /**
-     * Returns default instance of SchemeRegistry
-     *
-     * @param fixNoHttpResponseException Whether to fix issue or not, by omitting SSL verification
-     * @param httpPort                   HTTP port to be used, must be greater than 0
-     * @param httpsPort                  HTTPS port to be used, must be greater than 0
-     */
-    private static SchemeRegistry getDefaultSchemeRegistry(boolean fixNoHttpResponseException, int httpPort, int httpsPort) {
-        if (fixNoHttpResponseException) {
-            Log.d(LOG_TAG, "Beware! Using the fix is insecure, as it doesn't verify SSL certificates.");
-        }
-
-        if (httpPort < 1) {
-            httpPort = 80;
-            Log.d(LOG_TAG, "Invalid HTTP port number specified, defaulting to 80");
-        }
-
-        if (httpsPort < 1) {
-            httpsPort = 443;
-            Log.d(LOG_TAG, "Invalid HTTPS port number specified, defaulting to 443");
-        }
-
-        // Fix to SSL flaw in API < ICS
-        // See https://code.google.com/p/android/issues/detail?id=13117
-        SSLSocketFactory sslSocketFactory;
-        if (fixNoHttpResponseException) {
-            sslSocketFactory = MySSLSocketFactory.getFixedSocketFactory();
-        } else {
-            sslSocketFactory = SSLSocketFactory.getSocketFactory();
-        }
-
-        SchemeRegistry schemeRegistry = new SchemeRegistry();
-        schemeRegistry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), httpPort));
-        schemeRegistry.register(new Scheme("https", sslSocketFactory, httpsPort));
-
-        return schemeRegistry;
-    }
-
-    /**
-     * Creates a new AsyncHttpClient.
-     *
-     * @param schemeRegistry SchemeRegistry to be used
-     */
-    public AsyncHttpClient(SchemeRegistry schemeRegistry) {
-
-        BasicHttpParams httpParams = new BasicHttpParams();
-
-        ConnManagerParams.setTimeout(httpParams, connectTimeout);
-        ConnManagerParams.setMaxConnectionsPerRoute(httpParams, new ConnPerRouteBean(maxConnections));
-        ConnManagerParams.setMaxTotalConnections(httpParams, DEFAULT_MAX_CONNECTIONS);
-
-        HttpConnectionParams.setSoTimeout(httpParams, responseTimeout);
-        HttpConnectionParams.setConnectionTimeout(httpParams, connectTimeout);
-        HttpConnectionParams.setTcpNoDelay(httpParams, true);
-        HttpConnectionParams.setSocketBufferSize(httpParams, DEFAULT_SOCKET_BUFFER_SIZE);
-
-        HttpProtocolParams.setVersion(httpParams, HttpVersion.HTTP_1_1);
-
-        ClientConnectionManager cm = createConnectionManager(schemeRegistry, httpParams);
-        Utils.asserts(cm != null, "Custom implementation of #createConnectionManager(SchemeRegistry, BasicHttpParams) returned null");
-
-        threadPool = getDefaultThreadPool();
-        requestMap = Collections.synchronizedMap(new WeakHashMap<Context, List<RequestHandle>>());
-        clientHeaderMap = new HashMap<String, String>();
-
-        httpContext = new SyncBasicHttpContext(new BasicHttpContext());
-        httpClient = new DefaultHttpClient(cm, httpParams);
-        httpClient.addRequestInterceptor(new HttpRequestInterceptor() {
-            @Override
-            public void process(HttpRequest request, HttpContext context) {
-                if (!request.containsHeader(HEADER_ACCEPT_ENCODING)) {
-                    request.addHeader(HEADER_ACCEPT_ENCODING, ENCODING_GZIP);
-                }
-                for (String header : clientHeaderMap.keySet()) {
-                    if (request.containsHeader(header)) {
-                        Header overwritten = request.getFirstHeader(header);
-                        Log.d(LOG_TAG,
-                                String.format("Headers were overwritten! (%s | %s) overwrites (%s | %s)",
-                                        header, clientHeaderMap.get(header),
-                                        overwritten.getName(), overwritten.getValue())
-                        );
-
-                        //remove the overwritten header
-                        request.removeHeader(overwritten);
-                    }
-                    request.addHeader(header, clientHeaderMap.get(header));
-                }
-            }
-        });
-
-        httpClient.addResponseInterceptor(new HttpResponseInterceptor() {
-            @Override
-            public void process(HttpResponse response, HttpContext context) {
-                final HttpEntity entity = response.getEntity();
-                if (entity == null) {
-                    return;
-                }
-                final Header encoding = entity.getContentEncoding();
-                if (encoding != null) {
-                    for (HeaderElement element : encoding.getElements()) {
-                        if (element.getName().equalsIgnoreCase(ENCODING_GZIP)) {
-                            response.setEntity(new InflatingEntity(entity));
-                            break;
-                        }
-                    }
-                }
-            }
-        });
-
-        httpClient.addRequestInterceptor(new HttpRequestInterceptor() {
-            @Override
-            public void process(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
-                AuthState authState = (AuthState) context.getAttribute(ClientContext.TARGET_AUTH_STATE);
-                CredentialsProvider credsProvider = (CredentialsProvider) context.getAttribute(
-                        ClientContext.CREDS_PROVIDER);
-                HttpHost targetHost = (HttpHost) context.getAttribute(ExecutionContext.HTTP_TARGET_HOST);
-
-                if (authState.getAuthScheme() == null) {
-                    AuthScope authScope = new AuthScope(targetHost.getHostName(), targetHost.getPort());
-                    Credentials creds = credsProvider.getCredentials(authScope);
-                    if (creds != null) {
-                        authState.setAuthScheme(new BasicScheme());
-                        authState.setCredentials(creds);
-                    }
-                }
-            }
-        }, 0);
-
-        httpClient.setHttpRequestRetryHandler(new RetryHandler(DEFAULT_MAX_RETRIES, DEFAULT_RETRY_SLEEP_TIME_MILLIS));
-    }
-
-    public static void allowRetryExceptionClass(Class<?> cls) {
-        if (cls != null) {
-            RetryHandler.addClassToWhitelist(cls);
-        }
-    }
-
-    public static void blockRetryExceptionClass(Class<?> cls) {
-        if (cls != null) {
-            RetryHandler.addClassToBlacklist(cls);
-        }
-    }
-
-    /**
-     * Get the underlying HttpClient instance. This is useful for setting additional fine-grained
-     * settings for requests by accessing the client's ConnectionManager, HttpParams and
-     * SchemeRegistry.
-     *
-     * @return underlying HttpClient instance
-     */
-    public HttpClient getHttpClient() {
-        return this.httpClient;
-    }
-
-    /**
-     * Get the underlying HttpContext instance. This is useful for getting and setting fine-grained
-     * settings for requests by accessing the context's attributes such as the CookieStore.
-     *
-     * @return underlying HttpContext instance
-     */
-    public HttpContext getHttpContext() {
-        return this.httpContext;
-    }
-
-    /**
-     * Sets an optional CookieStore to use when making requests
-     *
-     * @param cookieStore The CookieStore implementation to use, usually an instance of {@link
-     *                    PersistentCookieStore}
-     */
-    public void setCookieStore(CookieStore cookieStore) {
-        httpContext.setAttribute(ClientContext.COOKIE_STORE, cookieStore);
-    }
-
-    /**
-     * Overrides the threadpool implementation used when queuing/pooling requests. By default,
-     * Executors.newCachedThreadPool() is used.
-     *
-     * @param threadPool an instance of {@link ExecutorService} to use for queuing/pooling
-     *                   requests.
-     */
-    public void setThreadPool(ExecutorService threadPool) {
-        this.threadPool = threadPool;
-    }
-
-    /**
-     * Returns the current executor service used. By default, Executors.newCachedThreadPool() is
-     * used.
-     *
-     * @return current executor service used
-     */
-    public ExecutorService getThreadPool() {
-        return threadPool;
-    }
-
-    /**
-     * Get the default threading pool to be used for this HTTP client.
-     *
-     * @return The default threading pool to be used
-     */
-    protected ExecutorService getDefaultThreadPool() {
-        return Executors.newCachedThreadPool();
-    }
-
-    /**
-     * Provided so it is easier for developers to provide custom ThreadSafeClientConnManager implementation
-     *
-     * @param schemeRegistry SchemeRegistry, usually provided by {@link #getDefaultSchemeRegistry(boolean, int, int)}
-     * @param httpParams     BasicHttpParams
-     * @return ClientConnectionManager instance
-     */
-    protected ClientConnectionManager createConnectionManager(SchemeRegistry schemeRegistry, BasicHttpParams httpParams) {
-        return new ThreadSafeClientConnManager(httpParams, schemeRegistry);
-    }
-
-    /**
-     * Simple interface method, to enable or disable redirects. If you set manually RedirectHandler
-     * on underlying HttpClient, effects of this method will be canceled. <p>&nbsp;</p> Default
-     * setting is to disallow redirects.
-     *
-     * @param enableRedirects         boolean
-     * @param enableRelativeRedirects boolean
-     * @param enableCircularRedirects boolean
-     */
-    public void setEnableRedirects(final boolean enableRedirects, final boolean enableRelativeRedirects, final boolean enableCircularRedirects) {
-        httpClient.getParams().setBooleanParameter(ClientPNames.REJECT_RELATIVE_REDIRECT, !enableRelativeRedirects);
-        httpClient.getParams().setBooleanParameter(ClientPNames.ALLOW_CIRCULAR_REDIRECTS, enableCircularRedirects);
-        httpClient.setRedirectHandler(new MyRedirectHandler(enableRedirects));
-    }
-
-    /**
-     * Circular redirects are enabled by default
-     *
-     * @param enableRedirects         boolean
-     * @param enableRelativeRedirects boolean
-     * @see #setEnableRedirects(boolean, boolean, boolean)
-     */
-    public void setEnableRedirects(final boolean enableRedirects, final boolean enableRelativeRedirects) {
-        setEnableRedirects(enableRedirects, enableRelativeRedirects, true);
-    }
-
-    /**
-     * @param enableRedirects boolean
-     * @see #setEnableRedirects(boolean, boolean, boolean)
-     */
-    public void setEnableRedirects(final boolean enableRedirects) {
-        setEnableRedirects(enableRedirects, enableRedirects, enableRedirects);
-    }
-
-    /**
-     * Allows you to set custom RedirectHandler implementation, if the default provided doesn't suit
-     * your needs
-     *
-     * @param customRedirectHandler RedirectHandler instance
-     * @see com.loopj.android.http.MyRedirectHandler
-     */
-    public void setRedirectHandler(final RedirectHandler customRedirectHandler) {
-        httpClient.setRedirectHandler(customRedirectHandler);
-    }
-
-    /**
-     * Sets the User-Agent header to be sent with each request. By default, "Android Asynchronous
-     * Http Client/VERSION (http://loopj.com/android-async-http/)" is used.
-     *
-     * @param userAgent the string to use in the User-Agent header.
-     */
-    public void setUserAgent(String userAgent) {
-        HttpProtocolParams.setUserAgent(this.httpClient.getParams(), userAgent);
-    }
-
-
-    /**
-     * Returns current limit of parallel connections
-     *
-     * @return maximum limit of parallel connections, default is 10
-     */
-    public int getMaxConnections() {
-        return maxConnections;
-    }
-
-    /**
-     * Sets maximum limit of parallel connections
-     *
-     * @param maxConnections maximum parallel connections, must be at least 1
-     */
-    public void setMaxConnections(int maxConnections) {
-        if (maxConnections < 1)
-            maxConnections = DEFAULT_MAX_CONNECTIONS;
-        this.maxConnections = maxConnections;
-        final HttpParams httpParams = this.httpClient.getParams();
-        ConnManagerParams.setMaxConnectionsPerRoute(httpParams, new ConnPerRouteBean(this.maxConnections));
-    }
-
-    /**
-     * Returns current socket timeout limit (milliseconds). By default, this is
-     * set to 10 seconds.
-     *
-     * @return Socket Timeout limit in milliseconds
-     * @deprecated Use either {@link #getConnectTimeout()} or {@link #getResponseTimeout()}
-     */
-    public int getTimeout() {
-        return connectTimeout;
-    }
-
-    /**
-     * Set both the connection and socket timeouts. By default, both are set to
-     * 10 seconds.
-     *
-     * @param value the connect/socket timeout in milliseconds, at least 1 second
-     * @see #setConnectTimeout(int)
-     * @see #setResponseTimeout(int)
-     */
-    public void setTimeout(int value) {
-        value = value < 1000 ? DEFAULT_SOCKET_TIMEOUT : value;
-        setConnectTimeout(value);
-        setResponseTimeout(value);
-    }
-
-    /**
-     * Returns current connection timeout limit (milliseconds). By default, this
-     * is set to 10 seconds.
-     *
-     * @return Connection timeout limit in milliseconds
-     */
-    public int getConnectTimeout() {
-        return connectTimeout;
-    }
-
-    /**
-     * Set connection timeout limit (milliseconds). By default, this is set to
-     * 10 seconds.
-     *
-     * @param value Connection timeout in milliseconds, minimal value is 1000 (1 second).
-     */
-    public void setConnectTimeout(int value) {
-        connectTimeout = value < 1000 ? DEFAULT_SOCKET_TIMEOUT : value;
-        final HttpParams httpParams = httpClient.getParams();
-        ConnManagerParams.setTimeout(httpParams, connectTimeout);
-        HttpConnectionParams.setConnectionTimeout(httpParams, connectTimeout);
-    }
-
-    /**
-     * Returns current response timeout limit (milliseconds). By default, this
-     * is set to 10 seconds.
-     *
-     * @return Response timeout limit in milliseconds
-     */
-    public int getResponseTimeout() {
-        return responseTimeout;
-    }
-
-    /**
-     * Set response timeout limit (milliseconds). By default, this is set to
-     * 10 seconds.
-     *
-     * @param value Response timeout in milliseconds, minimal value is 1000 (1 second).
-     */
-    public void setResponseTimeout(int value) {
-        responseTimeout = value < 1000 ? DEFAULT_SOCKET_TIMEOUT : value;
-        final HttpParams httpParams = httpClient.getParams();
-        HttpConnectionParams.setSoTimeout(httpParams, responseTimeout);
-    }
-
-    /**
-     * Sets the Proxy by it's hostname and port
-     *
-     * @param hostname the hostname (IP or DNS name)
-     * @param port     the port number. -1 indicates the scheme default port.
-     */
-    public void setProxy(String hostname, int port) {
-        final HttpHost proxy = new HttpHost(hostname, port);
-        final HttpParams httpParams = this.httpClient.getParams();
-        httpParams.setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-    }
-
-    /**
-     * Sets the Proxy by it's hostname,port,username and password
-     *
-     * @param hostname the hostname (IP or DNS name)
-     * @param port     the port number. -1 indicates the scheme default port.
-     * @param username the username
-     * @param password the password
-     */
-    public void setProxy(String hostname, int port, String username, String password) {
-        httpClient.getCredentialsProvider().setCredentials(
-                new AuthScope(hostname, port),
-                new UsernamePasswordCredentials(username, password));
-        final HttpHost proxy = new HttpHost(hostname, port);
-        final HttpParams httpParams = this.httpClient.getParams();
-        httpParams.setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-    }
-
-    /**
-     * Sets the SSLSocketFactory to user when making requests. By default, a new, default
-     * SSLSocketFactory is used.
-     *
-     * @param sslSocketFactory the socket factory to use for https requests.
-     */
-    public void setSSLSocketFactory(SSLSocketFactory sslSocketFactory) {
-        this.httpClient.getConnectionManager().getSchemeRegistry().register(new Scheme("https", sslSocketFactory, 443));
-    }
-
-    /**
-     * Sets the maximum number of retries and timeout for a particular Request.
-     *
-     * @param retries maximum number of retries per request
-     * @param timeout sleep between retries in milliseconds
-     */
-    public void setMaxRetriesAndTimeout(int retries, int timeout) {
-        this.httpClient.setHttpRequestRetryHandler(new RetryHandler(retries, timeout));
-    }
-
-    /**
-     * Will, before sending, remove all headers currently present in AsyncHttpClient instance, which
-     * applies on all requests this client makes
-     */
-    public void removeAllHeaders() {
-        clientHeaderMap.clear();
-    }
-
-    /**
-     * Sets headers that will be added to all requests this client makes (before sending).
-     *
-     * @param header the name of the header
-     * @param value  the contents of the header
-     */
-    public void addHeader(String header, String value) {
-        clientHeaderMap.put(header, value);
-    }
-
-    /**
-     * Remove header from all requests this client makes (before sending).
-     *
-     * @param header the name of the header
-     */
-    public void removeHeader(String header) {
-        clientHeaderMap.remove(header);
-    }
-
-    /**
-     * Sets basic authentication for the request. Uses AuthScope.ANY. This is the same as
-     * setBasicAuth('username','password',AuthScope.ANY)
-     *
-     * @param username Basic Auth username
-     * @param password Basic Auth password
-     */
-    public void setBasicAuth(String username, String password) {
-        setBasicAuth(username, password, false);
-    }
-
-    /**
-     * Sets basic authentication for the request. Uses AuthScope.ANY. This is the same as
-     * setBasicAuth('username','password',AuthScope.ANY)
-     *
-     * @param username  Basic Auth username
-     * @param password  Basic Auth password
-     * @param preemtive sets authorization in preemtive manner
-     */
-    public void setBasicAuth(String username, String password, boolean preemtive) {
-        setBasicAuth(username, password, null, preemtive);
-    }
-
-    /**
-     * Sets basic authentication for the request. You should pass in your AuthScope for security. It
-     * should be like this setBasicAuth("username","password", new AuthScope("host",port,AuthScope.ANY_REALM))
-     *
-     * @param username Basic Auth username
-     * @param password Basic Auth password
-     * @param scope    - an AuthScope object
-     */
-    public void setBasicAuth(String username, String password, AuthScope scope) {
-        setBasicAuth(username, password, scope, false);
-    }
-
-    /**
-     * Sets basic authentication for the request. You should pass in your AuthScope for security. It
-     * should be like this setBasicAuth("username","password", new AuthScope("host",port,AuthScope.ANY_REALM))
-     *
-     * @param username  Basic Auth username
-     * @param password  Basic Auth password
-     * @param scope     an AuthScope object
-     * @param preemtive sets authorization in preemtive manner
-     */
-    public void setBasicAuth(String username, String password, AuthScope scope, boolean preemtive) {
-        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password);
-        setCredentials(scope, credentials);
-        setAuthenticationPreemptive(preemtive);
-    }
-
-    public void setCredentials(AuthScope authScope, Credentials credentials) {
-        if (credentials == null) {
-            Log.d(LOG_TAG, "Provided credentials are null, not setting");
-            return;
-        }
-        this.httpClient.getCredentialsProvider().setCredentials(authScope == null ? AuthScope.ANY : authScope, credentials);
-    }
-
-    /**
-     * Sets HttpRequestInterceptor which handles authorization in preemtive way, as workaround you
-     * can use call `AsyncHttpClient.addHeader("Authorization","Basic base64OfUsernameAndPassword==")`
-     *
-     * @param isPreemtive whether the authorization is processed in preemtive way
-     */
-    public void setAuthenticationPreemptive(boolean isPreemtive) {
-        if (isPreemtive) {
-            httpClient.addRequestInterceptor(new PreemtiveAuthorizationHttpRequestInterceptor(), 0);
-        } else {
-            httpClient.removeRequestInterceptorByClass(PreemtiveAuthorizationHttpRequestInterceptor.class);
-        }
-    }
-
-    /**
-     * Removes previously set basic auth credentials
-     *
-     * @deprecated
-     */
-    @Deprecated
-    public void clearBasicAuth() {
-        clearCredentialsProvider();
-    }
-
-    /**
-     * Removes previously set auth credentials
-     */
-    public void clearCredentialsProvider() {
-        this.httpClient.getCredentialsProvider().clear();
-    }
-
-    /**
-     * Cancels any pending (or potentially active) requests associated with the passed Context.
-     * <p>&nbsp;</p> <b>Note:</b> This will only affect requests which were created with a non-null
-     * android Context. This method is intended to be used in the onDestroy method of your android
-     * activities to destroy all requests which are no longer required.
-     *
-     * @param context               the android Context instance associated to the request.
-     * @param mayInterruptIfRunning specifies if active requests should be cancelled along with
-     *                              pending requests.
-     */
-    public void cancelRequests(final Context context, final boolean mayInterruptIfRunning) {
-        if (context == null) {
-            Log.e(LOG_TAG, "Passed null Context to cancelRequests");
-            return;
-        }
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                List<RequestHandle> requestList = requestMap.get(context);
-                if (requestList != null) {
-                    for (RequestHandle requestHandle : requestList) {
-                        requestHandle.cancel(mayInterruptIfRunning);
-                    }
-                    requestMap.remove(context);
-                }
-            }
-        };
-        if (Looper.myLooper() == Looper.getMainLooper()) {
-            new Thread(r).start();
-        } else {
-            r.run();
-        }
-    }
-
-    /**
-     * Cancels all pending (or potentially active) requests. <p>&nbsp;</p> <b>Note:</b> This will
-     * only affect requests which were created with a non-null android Context. This method is
-     * intended to be used in the onDestroy method of your android activities to destroy all
-     * requests which are no longer required.
-     *
-     * @param mayInterruptIfRunning specifies if active requests should be cancelled along with
-     *                              pending requests.
-     */
-    public void cancelAllRequests(boolean mayInterruptIfRunning) {
-        for (List<RequestHandle> requestList : requestMap.values()) {
-            if (requestList != null) {
-                for (RequestHandle requestHandle : requestList) {
-                    requestHandle.cancel(mayInterruptIfRunning);
-                }
-            }
-        }
-        requestMap.clear();
-    }
-
-    // [+] HTTP HEAD
-
-    /**
-     * Perform a HTTP HEAD request, without any parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle head(String url, ResponseHandlerInterface responseHandler) {
-        return head(null, url, null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP HEAD request with parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param params          additional HEAD parameters to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle head(String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return head(null, url, params, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP HEAD request without any parameters and track the Android Context which
-     * initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle head(Context context, String url, ResponseHandlerInterface responseHandler) {
-        return head(context, url, null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP HEAD request and track the Android Context which initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param params          additional HEAD parameters to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle head(Context context, String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return sendRequest(httpClient, httpContext, new HttpHead(getUrlWithQueryString(isUrlEncodingEnabled, url, params)), null, responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP HEAD request and track the Android Context which initiated the request with
-     * customized headers
-     *
-     * @param context         Context to execute request against
-     * @param url             the URL to send the request to.
-     * @param headers         set headers only for this request
-     * @param params          additional HEAD parameters to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle head(Context context, String url, Header[] headers, RequestParams params, ResponseHandlerInterface responseHandler) {
-        HttpUriRequest request = new HttpHead(getUrlWithQueryString(isUrlEncodingEnabled, url, params));
-        if (headers != null) request.setHeaders(headers);
-        return sendRequest(httpClient, httpContext, request, null, responseHandler,
-                context);
-    }
-
-    // [-] HTTP HEAD
-    // [+] HTTP GET
-
-    /**
-     * Perform a HTTP GET request, without any parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle get(String url, ResponseHandlerInterface responseHandler) {
-        return get(null, url, null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP GET request with parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param params          additional GET parameters to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle get(String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return get(null, url, params, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP GET request without any parameters and track the Android Context which
-     * initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle get(Context context, String url, ResponseHandlerInterface responseHandler) {
-        return get(context, url, null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP GET request and track the Android Context which initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param params          additional GET parameters to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle get(Context context, String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return sendRequest(httpClient, httpContext, new HttpGet(getUrlWithQueryString(isUrlEncodingEnabled, url, params)), null, responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP GET request and track the Android Context which initiated the request with
-     * customized headers
-     *
-     * @param context         Context to execute request against
-     * @param url             the URL to send the request to.
-     * @param headers         set headers only for this request
-     * @param params          additional GET parameters to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle get(Context context, String url, Header[] headers, RequestParams params, ResponseHandlerInterface responseHandler) {
-        HttpUriRequest request = new HttpGet(getUrlWithQueryString(isUrlEncodingEnabled, url, params));
-        if (headers != null) request.setHeaders(headers);
-        return sendRequest(httpClient, httpContext, request, null, responseHandler,
-                context);
-    }
-
-    // [-] HTTP GET
-    // [+] HTTP POST
-
-    /**
-     * Perform a HTTP POST request, without any parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle post(String url, ResponseHandlerInterface responseHandler) {
-        return post(null, url, null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP POST request with parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param params          additional POST parameters or files to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle post(String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return post(null, url, params, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP POST request and track the Android Context which initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param params          additional POST parameters or files to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle post(Context context, String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return post(context, url, paramsToEntity(params, responseHandler), null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP POST request and track the Android Context which initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param entity          a raw {@link org.apache.http.HttpEntity} to send with the request, for
-     *                        example, use this to send string/json/xml payloads to a server by
-     *                        passing a {@link org.apache.http.entity.StringEntity}.
-     * @param contentType     the content type of the payload you are sending, for example
-     *                        application/json if sending a json payload.
-     * @param responseHandler the response ha   ndler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle post(Context context, String url, HttpEntity entity, String contentType, ResponseHandlerInterface responseHandler) {
-        return sendRequest(httpClient, httpContext, addEntityToRequestBase(new HttpPost(URI.create(url).normalize()), entity), contentType, responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP POST request and track the Android Context which initiated the request. Set
-     * headers only for this request
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param headers         set headers only for this request
-     * @param params          additional POST parameters to send with the request.
-     * @param contentType     the content type of the payload you are sending, for example
-     *                        application/json if sending a json payload.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle post(Context context, String url, Header[] headers, RequestParams params, String contentType,
-                              ResponseHandlerInterface responseHandler) {
-        HttpEntityEnclosingRequestBase request = new HttpPost(URI.create(url).normalize());
-        if (params != null) request.setEntity(paramsToEntity(params, responseHandler));
-        if (headers != null) request.setHeaders(headers);
-        return sendRequest(httpClient, httpContext, request, contentType,
-                responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP POST request and track the Android Context which initiated the request. Set
-     * headers only for this request
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param headers         set headers only for this request
-     * @param entity          a raw {@link HttpEntity} to send with the request, for example, use
-     *                        this to send string/json/xml payloads to a server by passing a {@link
-     *                        org.apache.http.entity.StringEntity}.
-     * @param contentType     the content type of the payload you are sending, for example
-     *                        application/json if sending a json payload.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle post(Context context, String url, Header[] headers, HttpEntity entity, String contentType,
-                              ResponseHandlerInterface responseHandler) {
-        HttpEntityEnclosingRequestBase request = addEntityToRequestBase(new HttpPost(URI.create(url).normalize()), entity);
-        if (headers != null) request.setHeaders(headers);
-        return sendRequest(httpClient, httpContext, request, contentType, responseHandler, context);
-    }
-
-    // [-] HTTP POST
-    // [+] HTTP PUT
-
-    /**
-     * Perform a HTTP PUT request, without any parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle put(String url, ResponseHandlerInterface responseHandler) {
-        return put(null, url, null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP PUT request with parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param params          additional PUT parameters or files to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle put(String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return put(null, url, params, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP PUT request and track the Android Context which initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param params          additional PUT parameters or files to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle put(Context context, String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return put(context, url, paramsToEntity(params, responseHandler), null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP PUT request and track the Android Context which initiated the request. And set
-     * one-time headers for the request
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param entity          a raw {@link HttpEntity} to send with the request, for example, use
-     *                        this to send string/json/xml payloads to a server by passing a {@link
-     *                        org.apache.http.entity.StringEntity}.
-     * @param contentType     the content type of the payload you are sending, for example
-     *                        application/json if sending a json payload.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle put(Context context, String url, HttpEntity entity, String contentType, ResponseHandlerInterface responseHandler) {
-        return sendRequest(httpClient, httpContext, addEntityToRequestBase(new HttpPut(URI.create(url).normalize()), entity), contentType, responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP PUT request and track the Android Context which initiated the request. And set
-     * one-time headers for the request
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param headers         set one-time headers for this request
-     * @param entity          a raw {@link HttpEntity} to send with the request, for example, use
-     *                        this to send string/json/xml payloads to a server by passing a {@link
-     *                        org.apache.http.entity.StringEntity}.
-     * @param contentType     the content type of the payload you are sending, for example
-     *                        application/json if sending a json payload.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle put(Context context, String url, Header[] headers, HttpEntity entity, String contentType, ResponseHandlerInterface responseHandler) {
-        HttpEntityEnclosingRequestBase request = addEntityToRequestBase(new HttpPut(URI.create(url).normalize()), entity);
-        if (headers != null) request.setHeaders(headers);
-        return sendRequest(httpClient, httpContext, request, contentType, responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP PATCH request, without any parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle patch(String url, ResponseHandlerInterface responseHandler) {
-        return patch(null, url, null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP PATCH request with parameters.
-     *
-     * @param url             the URL to send the request to.
-     * @param params          additional PUT parameters or files to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle patch(String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return patch(null, url, params, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP PATCH request and track the Android Context which initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param params          additional PUT parameters or files to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle patch(Context context, String url, RequestParams params, ResponseHandlerInterface responseHandler) {
-        return patch(context, url, paramsToEntity(params, responseHandler), null, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP PATCH request and track the Android Context which initiated the request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle patch(Context context, String url, HttpEntity entity, String contentType, ResponseHandlerInterface responseHandler) {
-        return sendRequest(httpClient, httpContext, addEntityToRequestBase(new HttpPatch(URI.create(url).normalize()), entity), contentType, responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP PATCH request and track the Android Context which initiated the request. And set
-     * one-time headers for the request
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param headers         set one-time headers for this request
-     * @param entity          a raw {@link HttpEntity} to send with the request, for example, use
-     *                        this to send string/json/xml payloads to a server by passing a {@link
-     *                        org.apache.http.entity.StringEntity}.
-     * @param contentType     the content type of the payload you are sending, for example
-     *                        application/json if sending a json payload.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle patch(Context context, String url, Header[] headers, HttpEntity entity, String contentType, ResponseHandlerInterface responseHandler) {
-        HttpEntityEnclosingRequestBase request = addEntityToRequestBase(new HttpPatch(URI.create(url).normalize()), entity);
-        if (headers != null) request.setHeaders(headers);
-        return sendRequest(httpClient, httpContext, request, contentType, responseHandler, context);
-    }
-
-    // [-] HTTP PUT
-    // [+] HTTP DELETE
-
-    /**
-     * Perform a HTTP DELETE request.
-     *
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle delete(String url, ResponseHandlerInterface responseHandler) {
-        return delete(null, url, responseHandler);
-    }
-
-    /**
-     * Perform a HTTP DELETE request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle delete(Context context, String url, ResponseHandlerInterface responseHandler) {
-        final HttpDelete delete = new HttpDelete(URI.create(url).normalize());
-        return sendRequest(httpClient, httpContext, delete, null, responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP DELETE request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param headers         set one-time headers for this request
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle delete(Context context, String url, Header[] headers, ResponseHandlerInterface responseHandler) {
-        final HttpDelete delete = new HttpDelete(URI.create(url).normalize());
-        if (headers != null) delete.setHeaders(headers);
-        return sendRequest(httpClient, httpContext, delete, null, responseHandler, context);
-    }
-
-    /**
-     * Perform a HTTP DELETE request.
-     *
-     * @param url             the URL to send the request to.
-     * @param params          additional DELETE parameters or files to send with the request.
-     * @param responseHandler the response handler instance that should handle the response.
-     */
-    public void delete(String url, RequestParams params, AsyncHttpResponseHandler responseHandler) {
-        final HttpDelete delete = new HttpDelete(getUrlWithQueryString(isUrlEncodingEnabled, url, params));
-        sendRequest(httpClient, httpContext, delete, null, responseHandler, null);
-    }
-
-    /**
-     * Perform a HTTP DELETE request.
-     *
-     * @param context         the Android Context which initiated the request.
-     * @param url             the URL to send the request to.
-     * @param headers         set one-time headers for this request
-     * @param params          additional DELETE parameters or files to send along with request
-     * @param responseHandler the response handler instance that should handle the response.
-     * @return RequestHandle of future request process
-     */
-    public RequestHandle delete(Context context, String url, Header[] headers, RequestParams params, ResponseHandlerInterface responseHandler) {
-        HttpDelete httpDelete = new HttpDelete(getUrlWithQueryString(isUrlEncodingEnabled, url, params));
-        if (headers != null) httpDelete.setHeaders(headers);
-        return sendRequest(httpClient, httpContext, httpDelete, null, responseHandler, context);
-    }
-
-    // [-] HTTP DELETE
-
-    /**
-     * Instantiate a new asynchronous HTTP request for the passed parameters.
-     *
-     * @param client          HttpClient to be used for request, can differ in single requests
-     * @param contentType     MIME body type, for POST and PUT requests, may be null
-     * @param context         Context of Android application, to hold the reference of request
-     * @param httpContext     HttpContext in which the request will be executed
-     * @param responseHandler ResponseHandler or its subclass to put the response into
-     * @param uriRequest      instance of HttpUriRequest, which means it must be of HttpDelete,
-     *                        HttpPost, HttpGet, HttpPut, etc.
-     * @return AsyncHttpRequest ready to be dispatched
-     */
-    protected AsyncHttpRequest newAsyncHttpRequest(DefaultHttpClient client, HttpContext httpContext, HttpUriRequest uriRequest, String contentType, ResponseHandlerInterface responseHandler, Context context) {
-        return new AsyncHttpRequest(client, httpContext, uriRequest, responseHandler);
-    }
-
-    /**
-     * Puts a new request in queue as a new thread in pool to be executed
-     *
-     * @param client          HttpClient to be used for request, can differ in single requests
-     * @param contentType     MIME body type, for POST and PUT requests, may be null
-     * @param context         Context of Android application, to hold the reference of request
-     * @param httpContext     HttpContext in which the request will be executed
-     * @param responseHandler ResponseHandler or its subclass to put the response into
-     * @param uriRequest      instance of HttpUriRequest, which means it must be of HttpDelete,
-     *                        HttpPost, HttpGet, HttpPut, etc.
-     * @return RequestHandle of future request process
-     */
-    protected RequestHandle sendRequest(DefaultHttpClient client, HttpContext httpContext, HttpUriRequest uriRequest, String contentType, ResponseHandlerInterface responseHandler, Context context) {
-        if (uriRequest == null) {
-            throw new IllegalArgumentException("HttpUriRequest must not be null");
-        }
-
-        if (responseHandler == null) {
-            throw new IllegalArgumentException("ResponseHandler must not be null");
-        }
-
-        if (responseHandler.getUseSynchronousMode() && !responseHandler.getUsePoolThread()) {
-            throw new IllegalArgumentException("Synchronous ResponseHandler used in AsyncHttpClient. You should create your response handler in a looper thread or use SyncHttpClient instead.");
-        }
-
-        if (contentType != null) {
-            if (uriRequest instanceof HttpEntityEnclosingRequestBase && ((HttpEntityEnclosingRequestBase) uriRequest).getEntity() != null) {
-                Log.w(LOG_TAG, "Passed contentType will be ignored because HttpEntity sets content type");
-            } else {
-                uriRequest.setHeader(HEADER_CONTENT_TYPE, contentType);
-            }
-        }
-
-        responseHandler.setRequestHeaders(uriRequest.getAllHeaders());
-        responseHandler.setRequestURI(uriRequest.getURI());
-
-        AsyncHttpRequest request = newAsyncHttpRequest(client, httpContext, uriRequest, contentType, responseHandler, context);
-        threadPool.submit(request);
-        RequestHandle requestHandle = new RequestHandle(request);
-
-        if (context != null) {
-            // Add request to request map
-            List<RequestHandle> requestList = requestMap.get(context);
-            synchronized (requestMap) {
-                if (requestList == null) {
-                    requestList = Collections.synchronizedList(new LinkedList<RequestHandle>());
-                    requestMap.put(context, requestList);
-                }
-            }
-
-            requestList.add(requestHandle);
-
-            Iterator<RequestHandle> iterator = requestList.iterator();
-            while (iterator.hasNext()) {
-                if (iterator.next().shouldBeGarbageCollected()) {
-                    iterator.remove();
-                }
-            }
-        }
-
-        return requestHandle;
-    }
-
-    /**
-     * Sets state of URL encoding feature, see bug #227, this method allows you to turn off and on
-     * this auto-magic feature on-demand.
-     *
-     * @param enabled desired state of feature
-     */
-    public void setURLEncodingEnabled(boolean enabled) {
-        this.isUrlEncodingEnabled = enabled;
-    }
-
-    /**
-     * Will encode url, if not disabled, and adds params on the end of it
-     *
-     * @param url             String with URL, should be valid URL without params
-     * @param params          RequestParams to be appended on the end of URL
-     * @param shouldEncodeUrl whether url should be encoded (replaces spaces with %20)
-     * @return encoded url if requested with params appended if any available
-     */
-    public static String getUrlWithQueryString(boolean shouldEncodeUrl, String url, RequestParams params) {
-        if (url == null)
-            return null;
-
-        if (shouldEncodeUrl) {
-            try {
-                String decodedURL = URLDecoder.decode(url, "UTF-8");
-                URL _url = new URL(decodedURL);
-                URI _uri = new URI(_url.getProtocol(), _url.getUserInfo(), _url.getHost(), _url.getPort(), _url.getPath(), _url.getQuery(), _url.getRef());
-                url = _uri.toASCIIString();
-            } catch (Exception ex) {
-                // Should not really happen, added just for sake of validity
-                Log.e(LOG_TAG, "getUrlWithQueryString encoding URL", ex);
-            }
-        }
-
-        if (params != null) {
-            // Construct the query string and trim it, in case it
-            // includes any excessive white spaces.
-            String paramString = params.getParamString().trim();
-
-            // Only add the query string if it isn't empty and it
-            // isn't equal to '?'.
-            if (!paramString.equals("") && !paramString.equals("?")) {
-                url += url.contains("?") ? "&" : "?";
-                url += paramString;
-            }
-        }
-
-        return url;
-    }
-
-    /**
-     * Checks the InputStream if it contains  GZIP compressed data
-     *
-     * @param inputStream InputStream to be checked
-     * @return true or false if the stream contains GZIP compressed data
-     * @throws java.io.IOException
-     */
-    public static boolean isInputStreamGZIPCompressed(final PushbackInputStream inputStream) throws IOException {
-        if (inputStream == null)
-            return false;
-
-        byte[] signature = new byte[2];
-        int readStatus = inputStream.read(signature);
-        inputStream.unread(signature);
-        int streamHeader = ((int) signature[0] & 0xff) | ((signature[1] << 8) & 0xff00);
-        return readStatus == 2 && GZIPInputStream.GZIP_MAGIC == streamHeader;
-    }
-
-    /**
-     * A utility function to close an input stream without raising an exception.
-     *
-     * @param is input stream to close safely
-     */
-    public static void silentCloseInputStream(InputStream is) {
-        try {
-            if (is != null) {
-                is.close();
-            }
-        } catch (IOException e) {
-            Log.w(LOG_TAG, "Cannot close input stream", e);
-        }
-    }
-
-    /**
-     * A utility function to close an output stream without raising an exception.
-     *
-     * @param os output stream to close safely
-     */
-    public static void silentCloseOutputStream(OutputStream os) {
-        try {
-            if (os != null) {
-                os.close();
-            }
-        } catch (IOException e) {
-            Log.w(LOG_TAG, "Cannot close output stream", e);
-        }
-    }
-
-    /**
-     * Returns HttpEntity containing data from RequestParams included with request declaration.
-     * Allows also passing progress from upload via provided ResponseHandler
-     *
-     * @param params          additional request params
-     * @param responseHandler ResponseHandlerInterface or its subclass to be notified on progress
-     */
-    private HttpEntity paramsToEntity(RequestParams params, ResponseHandlerInterface responseHandler) {
-        HttpEntity entity = null;
-
-        try {
-            if (params != null) {
-                entity = params.getEntity(responseHandler);
-            }
-        } catch (IOException e) {
-            if (responseHandler != null) {
-                responseHandler.sendFailureMessage(0, null, null, e);
-            } else {
-                e.printStackTrace();
-            }
-        }
-
-        return entity;
-    }
-
-    public boolean isUrlEncodingEnabled() {
-        return isUrlEncodingEnabled;
-    }
-
-    /**
-     * Applicable only to HttpRequest methods extending HttpEntityEnclosingRequestBase, which is for
-     * example not DELETE
-     *
-     * @param entity      entity to be included within the request
-     * @param requestBase HttpRequest instance, must not be null
-     */
-    private HttpEntityEnclosingRequestBase addEntityToRequestBase(HttpEntityEnclosingRequestBase requestBase, HttpEntity entity) {
-        if (entity != null) {
-            requestBase.setEntity(entity);
-        }
-
-        return requestBase;
-    }
-
-    /**
-     * This horrible hack is required on Android, due to implementation of BasicManagedEntity, which
-     * doesn't chain call consumeContent on underlying wrapped HttpEntity
-     *
-     * @param entity HttpEntity, may be null
-     */
-    public static void endEntityViaReflection(HttpEntity entity) {
-        if (entity instanceof HttpEntityWrapper) {
-            try {
-                Field f = null;
-                Field[] fields = HttpEntityWrapper.class.getDeclaredFields();
-                for (Field ff : fields) {
-                    if (ff.getName().equals("wrappedEntity")) {
-                        f = ff;
-                        break;
-                    }
-                }
-                if (f != null) {
-                    f.setAccessible(true);
-                    HttpEntity wrapped = (HttpEntity) f.get(entity);
-                    if (wrapped != null) {
-                        wrapped.consumeContent();
-                    }
-                }
-            } catch (Throwable t) {
-                Log.e(LOG_TAG, "wrappedEntity consume", t);
-            }
-        }
-    }
-
-    /**
-     * Enclosing entity to hold stream of gzip decoded data for accessing HttpEntity contents
-     */
-    private static class InflatingEntity extends HttpEntityWrapper {
-
-        public InflatingEntity(HttpEntity wrapped) {
-            super(wrapped);
-        }
-
-        InputStream wrappedStream;
-        PushbackInputStream pushbackStream;
-        GZIPInputStream gzippedStream;
-
-        @Override
-        public InputStream getContent() throws IOException {
-            wrappedStream = wrappedEntity.getContent();
-            pushbackStream = new PushbackInputStream(wrappedStream, 2);
-            if (isInputStreamGZIPCompressed(pushbackStream)) {
-                gzippedStream = new GZIPInputStream(pushbackStream);
-                return gzippedStream;
-            } else {
-                return pushbackStream;
-            }
-        }
-
-        @Override
-        public long getContentLength() {
-            return wrappedEntity == null ? 0 : wrappedEntity.getContentLength();
-        }
-
-        @Override
-        public void consumeContent() throws IOException {
-            AsyncHttpClient.silentCloseInputStream(wrappedStream);
-            AsyncHttpClient.silentCloseInputStream(pushbackStream);
-            AsyncHttpClient.silentCloseInputStream(gzippedStream);
-            super.consumeContent();
-        }
-    }
+	public static final String LOG_TAG = "AsyncHttpClient";
+	public static final String HEADER_CONTENT_TYPE = "Content-Type";
+	public static final String HEADER_CONTENT_RANGE = "Content-Range";
+	public static final String HEADER_CONTENT_ENCODING = "Content-Encoding";
+	public static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
+	public static final String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
+	public static final String ENCODING_GZIP = "gzip";
+
+	public static final int DEFAULT_MAX_CONNECTIONS = 10;
+	public static final int DEFAULT_SOCKET_TIMEOUT = 10 * 1000;
+	public static final int DEFAULT_MAX_RETRIES = 5;
+	public static final int DEFAULT_RETRY_SLEEP_TIME_MILLIS = 1500;
+	public static final int DEFAULT_SOCKET_BUFFER_SIZE = 8192;
+
+	private int maxConnections = DEFAULT_MAX_CONNECTIONS;
+	private int connectTimeout = DEFAULT_SOCKET_TIMEOUT;
+	private int responseTimeout = DEFAULT_SOCKET_TIMEOUT;
+
+	private final DefaultHttpClient httpClient;
+	private final HttpContext httpContext;
+	private ExecutorService threadPool;
+	private final Map<Context, List<RequestHandle>> requestMap;
+	private final Map<String, String> clientHeaderMap;
+	private boolean isUrlEncodingEnabled = true;
+	private Context context;
+	private DiskBasedCache diskCache;
+	private boolean DEBUG=false;
+	/**
+	 * Creates a new AsyncHttpClient with default constructor arguments values
+	 */
+	public AsyncHttpClient(Context context) {
+		this(context,false, 80, 443);
+	}
+
+	/**
+	 * Creates a new AsyncHttpClient.
+	 * 
+	 * @param httpPort
+	 *            non-standard HTTP-only port
+	 */
+	public AsyncHttpClient(Context context,int httpPort) {
+		this(context,false, httpPort, 443);
+	}
+
+	/**
+	 * Creates a new AsyncHttpClient.
+	 * 
+	 * @param httpPort
+	 *            non-standard HTTP-only port
+	 * @param httpsPort
+	 *            non-standard HTTPS-only port
+	 */
+	public AsyncHttpClient(Context context,int httpPort, int httpsPort) {
+		this(context,false, httpPort, httpsPort);
+	}
+
+	/**
+	 * Creates new AsyncHttpClient using given params
+	 * 
+	 * @param fixNoHttpResponseException
+	 *            Whether to fix issue or not, by omitting SSL verification
+	 * @param httpPort
+	 *            HTTP port to be used, must be greater than 0
+	 * @param httpsPort
+	 *            HTTPS port to be used, must be greater than 0
+	 */
+	public AsyncHttpClient(Context context,boolean fixNoHttpResponseException, int httpPort,
+			int httpsPort) {
+		this(context,getDefaultSchemeRegistry(fixNoHttpResponseException, httpPort,
+				httpsPort));
+	}
+
+	/**
+	 * Returns default instance of SchemeRegistry
+	 * 
+	 * @param fixNoHttpResponseException
+	 *            Whether to fix issue or not, by omitting SSL verification
+	 * @param httpPort
+	 *            HTTP port to be used, must be greater than 0
+	 * @param httpsPort
+	 *            HTTPS port to be used, must be greater than 0
+	 */
+	private static SchemeRegistry getDefaultSchemeRegistry(
+			boolean fixNoHttpResponseException, int httpPort, int httpsPort) {
+		if (fixNoHttpResponseException) {
+			Log.d(LOG_TAG,
+					"Beware! Using the fix is insecure, as it doesn't verify SSL certificates.");
+		}
+
+		if (httpPort < 1) {
+			httpPort = 80;
+			Log.d(LOG_TAG,
+					"Invalid HTTP port number specified, defaulting to 80");
+		}
+
+		if (httpsPort < 1) {
+			httpsPort = 443;
+			Log.d(LOG_TAG,
+					"Invalid HTTPS port number specified, defaulting to 443");
+		}
+
+		// Fix to SSL flaw in API < ICS
+		// See https://code.google.com/p/android/issues/detail?id=13117
+		SSLSocketFactory sslSocketFactory;
+		if (fixNoHttpResponseException) {
+			sslSocketFactory = MySSLSocketFactory.getFixedSocketFactory();
+		} else {
+			sslSocketFactory = SSLSocketFactory.getSocketFactory();
+		}
+
+		SchemeRegistry schemeRegistry = new SchemeRegistry();
+		schemeRegistry.register(new Scheme("http", PlainSocketFactory
+				.getSocketFactory(), httpPort));
+		schemeRegistry
+				.register(new Scheme("https", sslSocketFactory, httpsPort));
+
+		return schemeRegistry;
+	}
+	
+	public void setDebug(boolean status){
+		this.DEBUG=status;
+	}
+
+	/**
+	 *  set DiskCahce
+	 * @param maxDiskCache MaxCache
+	 * @param timeOutDay   TiemOut
+	 */
+	public void setDiskCache(int maxDiskCache,int timeOutDay) {
+		diskCache.setMaxCache(maxDiskCache);	
+		diskCache.setTimeOutDay(timeOutDay);	
+	}
+	
+	public void setDiskCache(int maxDiskCache) {
+		diskCache.setMaxCache(maxDiskCache);		
+	}
+
+	/**
+	 * Creates a new AsyncHttpClient.
+	 * 
+	 * @param schemeRegistry
+	 *            SchemeRegistry to be used
+	 */
+	public AsyncHttpClient(Context context,SchemeRegistry schemeRegistry) {
+		this.context=context;
+		BasicHttpParams httpParams = new BasicHttpParams();
+		ConnManagerParams.setTimeout(httpParams, connectTimeout);
+		ConnManagerParams.setMaxConnectionsPerRoute(httpParams,
+				new ConnPerRouteBean(maxConnections));
+		ConnManagerParams.setMaxTotalConnections(httpParams,
+				DEFAULT_MAX_CONNECTIONS);
+
+		HttpConnectionParams.setSoTimeout(httpParams, responseTimeout);
+		HttpConnectionParams.setConnectionTimeout(httpParams, connectTimeout);
+		HttpConnectionParams.setTcpNoDelay(httpParams, true);
+		HttpConnectionParams.setSocketBufferSize(httpParams,
+				DEFAULT_SOCKET_BUFFER_SIZE);
+
+		HttpProtocolParams.setVersion(httpParams, HttpVersion.HTTP_1_1);
+
+		ClientConnectionManager cm = createConnectionManager(schemeRegistry,
+				httpParams);
+		Utils.asserts(
+				cm != null,
+				"Custom implementation of #createConnectionManager(SchemeRegistry, BasicHttpParams) returned null");
+
+		threadPool = getDefaultThreadPool();
+		requestMap = Collections
+				.synchronizedMap(new WeakHashMap<Context, List<RequestHandle>>());
+		clientHeaderMap = new HashMap<String, String>();
+
+		httpContext = new SyncBasicHttpContext(new BasicHttpContext());
+		httpClient = new DefaultHttpClient(cm, httpParams);
+		httpClient.addRequestInterceptor(new HttpRequestInterceptor() {
+			@Override
+			public void process(HttpRequest request, HttpContext context) {
+				if (!request.containsHeader(HEADER_ACCEPT_ENCODING)) {
+					request.addHeader(HEADER_ACCEPT_ENCODING, ENCODING_GZIP);
+				}
+				for (String header : clientHeaderMap.keySet()) {
+					if (request.containsHeader(header)) {
+						Header overwritten = request.getFirstHeader(header);
+						Log.d(LOG_TAG,
+								String.format(
+										"Headers were overwritten! (%s | %s) overwrites (%s | %s)",
+										header, clientHeaderMap.get(header),
+										overwritten.getName(),
+										overwritten.getValue()));
+
+						// remove the overwritten header
+						request.removeHeader(overwritten);
+					}
+					request.addHeader(header, clientHeaderMap.get(header));
+				}
+			}
+		});
+
+		httpClient.addResponseInterceptor(new HttpResponseInterceptor() {
+			@Override
+			public void process(HttpResponse response, HttpContext context) {
+				final HttpEntity entity = response.getEntity();
+				if (entity == null) {
+					return;
+				}
+				final Header encoding = entity.getContentEncoding();
+				if (encoding != null) {
+					for (HeaderElement element : encoding.getElements()) {
+						if (element.getName().equalsIgnoreCase(ENCODING_GZIP)) {
+							response.setEntity(new InflatingEntity(entity));
+							break;
+						}
+					}
+				}
+			}
+		});
+
+		httpClient.addRequestInterceptor(new HttpRequestInterceptor() {
+			@Override
+			public void process(final HttpRequest request,
+					final HttpContext context) throws HttpException,
+					IOException {
+				AuthState authState = (AuthState) context
+						.getAttribute(ClientContext.TARGET_AUTH_STATE);
+				CredentialsProvider credsProvider = (CredentialsProvider) context
+						.getAttribute(ClientContext.CREDS_PROVIDER);
+				HttpHost targetHost = (HttpHost) context
+						.getAttribute(ExecutionContext.HTTP_TARGET_HOST);
+
+				if (authState.getAuthScheme() == null) {
+					AuthScope authScope = new AuthScope(targetHost
+							.getHostName(), targetHost.getPort());
+					Credentials creds = credsProvider.getCredentials(authScope);
+					if (creds != null) {
+						authState.setAuthScheme(new BasicScheme());
+						authState.setCredentials(creds);
+					}
+				}
+			}
+		}, 0);
+
+		httpClient.setHttpRequestRetryHandler(new RetryHandler(
+				DEFAULT_MAX_RETRIES, DEFAULT_RETRY_SLEEP_TIME_MILLIS));
+		diskCache=DiskBasedCache.init(new File(android.os.Environment.getExternalStorageDirectory()+"/httpCache"));
+		diskCache.initialize();
+	}
+
+	public static void allowRetryExceptionClass(Class<?> cls) {
+		if (cls != null) {
+			RetryHandler.addClassToWhitelist(cls);
+		}
+	}
+
+	public static void blockRetryExceptionClass(Class<?> cls) {
+		if (cls != null) {
+			RetryHandler.addClassToBlacklist(cls);
+		}
+	}
+
+	/**
+	 * Get the underlying HttpClient instance. This is useful for setting
+	 * additional fine-grained settings for requests by accessing the client's
+	 * ConnectionManager, HttpParams and SchemeRegistry.
+	 * 
+	 * @return underlying HttpClient instance
+	 */
+	public HttpClient getHttpClient() {
+		return this.httpClient;
+	}
+
+	/**
+	 * Get the underlying HttpContext instance. This is useful for getting and
+	 * setting fine-grained settings for requests by accessing the context's
+	 * attributes such as the CookieStore.
+	 * 
+	 * @return underlying HttpContext instance
+	 */
+	public HttpContext getHttpContext() {
+		return this.httpContext;
+	}
+
+	/**
+	 * Sets an optional CookieStore to use when making requests
+	 * 
+	 * @param cookieStore
+	 *            The CookieStore implementation to use, usually an instance of
+	 *            {@link PersistentCookieStore}
+	 */
+	public void setCookieStore(CookieStore cookieStore) {
+		httpContext.setAttribute(ClientContext.COOKIE_STORE, cookieStore);
+	}
+
+	/**
+	 * Overrides the threadpool implementation used when queuing/pooling
+	 * requests. By default, Executors.newCachedThreadPool() is used.
+	 * 
+	 * @param threadPool
+	 *            an instance of {@link ExecutorService} to use for
+	 *            queuing/pooling requests.
+	 */
+	public void setThreadPool(ExecutorService threadPool) {
+		this.threadPool = threadPool;
+	}
+
+	/**
+	 * Returns the current executor service used. By default,
+	 * Executors.newCachedThreadPool() is used.
+	 * 
+	 * @return current executor service used
+	 */
+	public ExecutorService getThreadPool() {
+		return threadPool;
+	}
+
+	/**
+	 * Get the default threading pool to be used for this HTTP client.
+	 * 
+	 * @return The default threading pool to be used
+	 */
+	protected ExecutorService getDefaultThreadPool() {
+		return Executors.newCachedThreadPool();
+	}
+
+	/**
+	 * Provided so it is easier for developers to provide custom
+	 * ThreadSafeClientConnManager implementation
+	 * 
+	 * @param schemeRegistry
+	 *            SchemeRegistry, usually provided by
+	 *            {@link #getDefaultSchemeRegistry(boolean, int, int)}
+	 * @param httpParams
+	 *            BasicHttpParams
+	 * @return ClientConnectionManager instance
+	 */
+	protected ClientConnectionManager createConnectionManager(
+			SchemeRegistry schemeRegistry, BasicHttpParams httpParams) {
+		return new ThreadSafeClientConnManager(httpParams, schemeRegistry);
+	}
+
+	/**
+	 * Simple interface method, to enable or disable redirects. If you set
+	 * manually RedirectHandler on underlying HttpClient, effects of this method
+	 * will be canceled.
+	 * <p>
+	 * &nbsp;
+	 * </p>
+	 * Default setting is to disallow redirects.
+	 * 
+	 * @param enableRedirects
+	 *            boolean
+	 * @param enableRelativeRedirects
+	 *            boolean
+	 * @param enableCircularRedirects
+	 *            boolean
+	 */
+	public void setEnableRedirects(final boolean enableRedirects,
+			final boolean enableRelativeRedirects,
+			final boolean enableCircularRedirects) {
+		httpClient.getParams()
+				.setBooleanParameter(ClientPNames.REJECT_RELATIVE_REDIRECT,
+						!enableRelativeRedirects);
+		httpClient.getParams().setBooleanParameter(
+				ClientPNames.ALLOW_CIRCULAR_REDIRECTS, enableCircularRedirects);
+		httpClient.setRedirectHandler(new MyRedirectHandler(enableRedirects));
+	}
+
+	/**
+	 * Circular redirects are enabled by default
+	 * 
+	 * @param enableRedirects
+	 *            boolean
+	 * @param enableRelativeRedirects
+	 *            boolean
+	 * @see #setEnableRedirects(boolean, boolean, boolean)
+	 */
+	public void setEnableRedirects(final boolean enableRedirects,
+			final boolean enableRelativeRedirects) {
+		setEnableRedirects(enableRedirects, enableRelativeRedirects, true);
+	}
+
+	/**
+	 * @param enableRedirects
+	 *            boolean
+	 * @see #setEnableRedirects(boolean, boolean, boolean)
+	 */
+	public void setEnableRedirects(final boolean enableRedirects) {
+		setEnableRedirects(enableRedirects, enableRedirects, enableRedirects);
+	}
+
+	/**
+	 * Allows you to set custom RedirectHandler implementation, if the default
+	 * provided doesn't suit your needs
+	 * 
+	 * @param customRedirectHandler
+	 *            RedirectHandler instance
+	 * @see com.loopj.android.http.MyRedirectHandler
+	 */
+	public void setRedirectHandler(final RedirectHandler customRedirectHandler) {
+		httpClient.setRedirectHandler(customRedirectHandler);
+	}
+
+	/**
+	 * Sets the User-Agent header to be sent with each request. By default,
+	 * "Android Asynchronous Http Client/VERSION
+	 * (http://loopj.com/android-async-http/)" is used.
+	 * 
+	 * @param userAgent
+	 *            the string to use in the User-Agent header.
+	 */
+	public void setUserAgent(String userAgent) {
+		HttpProtocolParams.setUserAgent(this.httpClient.getParams(), userAgent);
+	}
+
+	/**
+	 * Returns current limit of parallel connections
+	 * 
+	 * @return maximum limit of parallel connections, default is 10
+	 */
+	public int getMaxConnections() {
+		return maxConnections;
+	}
+
+	/**
+	 * Sets maximum limit of parallel connections
+	 * 
+	 * @param maxConnections
+	 *            maximum parallel connections, must be at least 1
+	 */
+	public void setMaxConnections(int maxConnections) {
+		if (maxConnections < 1)
+			maxConnections = DEFAULT_MAX_CONNECTIONS;
+		this.maxConnections = maxConnections;
+		final HttpParams httpParams = this.httpClient.getParams();
+		ConnManagerParams.setMaxConnectionsPerRoute(httpParams,
+				new ConnPerRouteBean(this.maxConnections));
+	}
+
+	/**
+	 * Returns current socket timeout limit (milliseconds). By default, this is
+	 * set to 10 seconds.
+	 * 
+	 * @return Socket Timeout limit in milliseconds
+	 * @deprecated Use either {@link #getConnectTimeout()} or
+	 *             {@link #getResponseTimeout()}
+	 */
+	public int getTimeout() {
+		return connectTimeout;
+	}
+
+	/**
+	 * Set both the connection and socket timeouts. By default, both are set to
+	 * 10 seconds.
+	 * 
+	 * @param value
+	 *            the connect/socket timeout in milliseconds, at least 1 second
+	 * @see #setConnectTimeout(int)
+	 * @see #setResponseTimeout(int)
+	 */
+	public void setTimeout(int value) {
+		value = value < 1000 ? DEFAULT_SOCKET_TIMEOUT : value;
+		setConnectTimeout(value);
+		setResponseTimeout(value);
+	}
+
+	/**
+	 * Returns current connection timeout limit (milliseconds). By default, this
+	 * is set to 10 seconds.
+	 * 
+	 * @return Connection timeout limit in milliseconds
+	 */
+	public int getConnectTimeout() {
+		return connectTimeout;
+	}
+
+	/**
+	 * Set connection timeout limit (milliseconds). By default, this is set to
+	 * 10 seconds.
+	 * 
+	 * @param value
+	 *            Connection timeout in milliseconds, minimal value is 1000 (1
+	 *            second).
+	 */
+	public void setConnectTimeout(int value) {
+		connectTimeout = value < 1000 ? DEFAULT_SOCKET_TIMEOUT : value;
+		final HttpParams httpParams = httpClient.getParams();
+		ConnManagerParams.setTimeout(httpParams, connectTimeout);
+		HttpConnectionParams.setConnectionTimeout(httpParams, connectTimeout);
+	}
+
+	/**
+	 * Returns current response timeout limit (milliseconds). By default, this
+	 * is set to 10 seconds.
+	 * 
+	 * @return Response timeout limit in milliseconds
+	 */
+	public int getResponseTimeout() {
+		return responseTimeout;
+	}
+
+	/**
+	 * Set response timeout limit (milliseconds). By default, this is set to 10
+	 * seconds.
+	 * 
+	 * @param value
+	 *            Response timeout in milliseconds, minimal value is 1000 (1
+	 *            second).
+	 */
+	public void setResponseTimeout(int value) {
+		responseTimeout = value < 1000 ? DEFAULT_SOCKET_TIMEOUT : value;
+		final HttpParams httpParams = httpClient.getParams();
+		HttpConnectionParams.setSoTimeout(httpParams, responseTimeout);
+	}
+
+	/**
+	 * Sets the Proxy by it's hostname and port
+	 * 
+	 * @param hostname
+	 *            the hostname (IP or DNS name)
+	 * @param port
+	 *            the port number. -1 indicates the scheme default port.
+	 */
+	public void setProxy(String hostname, int port) {
+		final HttpHost proxy = new HttpHost(hostname, port);
+		final HttpParams httpParams = this.httpClient.getParams();
+		httpParams.setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+	}
+
+	/**
+	 * Sets the Proxy by it's hostname,port,username and password
+	 * 
+	 * @param hostname
+	 *            the hostname (IP or DNS name)
+	 * @param port
+	 *            the port number. -1 indicates the scheme default port.
+	 * @param username
+	 *            the username
+	 * @param password
+	 *            the password
+	 */
+	public void setProxy(String hostname, int port, String username,
+			String password) {
+		httpClient.getCredentialsProvider().setCredentials(
+				new AuthScope(hostname, port),
+				new UsernamePasswordCredentials(username, password));
+		final HttpHost proxy = new HttpHost(hostname, port);
+		final HttpParams httpParams = this.httpClient.getParams();
+		httpParams.setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+	}
+
+	/**
+	 * Sets the SSLSocketFactory to user when making requests. By default, a
+	 * new, default SSLSocketFactory is used.
+	 * 
+	 * @param sslSocketFactory
+	 *            the socket factory to use for https requests.
+	 */
+	public void setSSLSocketFactory(SSLSocketFactory sslSocketFactory) {
+		this.httpClient.getConnectionManager().getSchemeRegistry()
+				.register(new Scheme("https", sslSocketFactory, 443));
+	}
+
+	/**
+	 * Sets the maximum number of retries and timeout for a particular Request.
+	 * 
+	 * @param retries
+	 *            maximum number of retries per request
+	 * @param timeout
+	 *            sleep between retries in milliseconds
+	 */
+	public void setMaxRetriesAndTimeout(int retries, int timeout) {
+		this.httpClient.setHttpRequestRetryHandler(new RetryHandler(retries,
+				timeout));
+	}
+
+	/**
+	 * Will, before sending, remove all headers currently present in
+	 * AsyncHttpClient instance, which applies on all requests this client makes
+	 */
+	public void removeAllHeaders() {
+		clientHeaderMap.clear();
+	}
+
+	/**
+	 * Sets headers that will be added to all requests this client makes (before
+	 * sending).
+	 * 
+	 * @param header
+	 *            the name of the header
+	 * @param value
+	 *            the contents of the header
+	 */
+	public void addHeader(String header, String value) {
+		clientHeaderMap.put(header, value);
+	}
+
+	/**
+	 * Remove header from all requests this client makes (before sending).
+	 * 
+	 * @param header
+	 *            the name of the header
+	 */
+	public void removeHeader(String header) {
+		clientHeaderMap.remove(header);
+	}
+
+	/**
+	 * Sets basic authentication for the request. Uses AuthScope.ANY. This is
+	 * the same as setBasicAuth('username','password',AuthScope.ANY)
+	 * 
+	 * @param username
+	 *            Basic Auth username
+	 * @param password
+	 *            Basic Auth password
+	 */
+	public void setBasicAuth(String username, String password) {
+		setBasicAuth(username, password, false);
+	}
+
+	/**
+	 * Sets basic authentication for the request. Uses AuthScope.ANY. This is
+	 * the same as setBasicAuth('username','password',AuthScope.ANY)
+	 * 
+	 * @param username
+	 *            Basic Auth username
+	 * @param password
+	 *            Basic Auth password
+	 * @param preemtive
+	 *            sets authorization in preemtive manner
+	 */
+	public void setBasicAuth(String username, String password, boolean preemtive) {
+		setBasicAuth(username, password, null, preemtive);
+	}
+
+	/**
+	 * Sets basic authentication for the request. You should pass in your
+	 * AuthScope for security. It should be like this
+	 * setBasicAuth("username","password", new
+	 * AuthScope("host",port,AuthScope.ANY_REALM))
+	 * 
+	 * @param username
+	 *            Basic Auth username
+	 * @param password
+	 *            Basic Auth password
+	 * @param scope
+	 *            - an AuthScope object
+	 */
+	public void setBasicAuth(String username, String password, AuthScope scope) {
+		setBasicAuth(username, password, scope, false);
+	}
+
+	/**
+	 * Sets basic authentication for the request. You should pass in your
+	 * AuthScope for security. It should be like this
+	 * setBasicAuth("username","password", new
+	 * AuthScope("host",port,AuthScope.ANY_REALM))
+	 * 
+	 * @param username
+	 *            Basic Auth username
+	 * @param password
+	 *            Basic Auth password
+	 * @param scope
+	 *            an AuthScope object
+	 * @param preemtive
+	 *            sets authorization in preemtive manner
+	 */
+	public void setBasicAuth(String username, String password, AuthScope scope,
+			boolean preemtive) {
+		UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
+				username, password);
+		setCredentials(scope, credentials);
+		setAuthenticationPreemptive(preemtive);
+	}
+
+	public void setCredentials(AuthScope authScope, Credentials credentials) {
+		if (credentials == null) {
+			Log.d(LOG_TAG, "Provided credentials are null, not setting");
+			return;
+		}
+		this.httpClient.getCredentialsProvider().setCredentials(
+				authScope == null ? AuthScope.ANY : authScope, credentials);
+	}
+
+	/**
+	 * Sets HttpRequestInterceptor which handles authorization in preemtive way,
+	 * as workaround you can use call
+	 * `AsyncHttpClient.addHeader("Authorization",
+	 * "Basic base64OfUsernameAndPassword==")`
+	 * 
+	 * @param isPreemtive
+	 *            whether the authorization is processed in preemtive way
+	 */
+	public void setAuthenticationPreemptive(boolean isPreemtive) {
+		if (isPreemtive) {
+			httpClient.addRequestInterceptor(
+					new PreemtiveAuthorizationHttpRequestInterceptor(), 0);
+		} else {
+			httpClient
+					.removeRequestInterceptorByClass(PreemtiveAuthorizationHttpRequestInterceptor.class);
+		}
+	}
+
+	/**
+	 * Removes previously set basic auth credentials
+	 * 
+	 * @deprecated
+	 */
+	@Deprecated
+	public void clearBasicAuth() {
+		clearCredentialsProvider();
+	}
+
+	/**
+	 * Removes previously set auth credentials
+	 */
+	public void clearCredentialsProvider() {
+		this.httpClient.getCredentialsProvider().clear();
+	}
+
+	/**
+	 * Cancels any pending (or potentially active) requests associated with the
+	 * passed Context.
+	 * <p>
+	 * &nbsp;
+	 * </p>
+	 * <b>Note:</b> This will only affect requests which were created with a
+	 * non-null android Context. This method is intended to be used in the
+	 * onDestroy method of your android activities to destroy all requests which
+	 * are no longer required.
+	 * 
+	 * @param context
+	 *            the android Context instance associated to the request.
+	 * @param mayInterruptIfRunning
+	 *            specifies if active requests should be cancelled along with
+	 *            pending requests.
+	 */
+	public void cancelRequests(final Context context,
+			final boolean mayInterruptIfRunning) {
+		if (context == null) {
+			Log.e(LOG_TAG, "Passed null Context to cancelRequests");
+			return;
+		}
+		Runnable r = new Runnable() {
+			@Override
+			public void run() {
+				List<RequestHandle> requestList = requestMap.get(context);
+				if (requestList != null) {
+					for (RequestHandle requestHandle : requestList) {
+						requestHandle.cancel(mayInterruptIfRunning);
+					}
+					requestMap.remove(context);
+				}
+			}
+		};
+		if (Looper.myLooper() == Looper.getMainLooper()) {
+			new Thread(r).start();
+		} else {
+			r.run();
+		}
+	}
+
+	/**
+	 * Cancels all pending (or potentially active) requests.
+	 * <p>
+	 * &nbsp;
+	 * </p>
+	 * <b>Note:</b> This will only affect requests which were created with a
+	 * non-null android Context. This method is intended to be used in the
+	 * onDestroy method of your android activities to destroy all requests which
+	 * are no longer required.
+	 * 
+	 * @param mayInterruptIfRunning
+	 *            specifies if active requests should be cancelled along with
+	 *            pending requests.
+	 */
+	public void cancelAllRequests(boolean mayInterruptIfRunning) {
+		for (List<RequestHandle> requestList : requestMap.values()) {
+			if (requestList != null) {
+				for (RequestHandle requestHandle : requestList) {
+					requestHandle.cancel(mayInterruptIfRunning);
+				}
+			}
+		}
+		requestMap.clear();
+	}
+
+	// [+] HTTP HEAD
+
+	/**
+	 * Perform a HTTP HEAD request, without any parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle head(String url,
+			ResponseHandlerInterface responseHandler) {
+		return head(null, url, null, responseHandler,true);
+	}
+
+	/**
+	 * Perform a HTTP HEAD request with parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional HEAD parameters to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle head(String url, RequestParams params,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return head(null, url, params, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP HEAD request without any parameters and track the Android
+	 * Context which initiated the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle head(Context context, String url,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return head(context, url, null, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP HEAD request and track the Android Context which initiated
+	 * the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional HEAD parameters to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	
+	public RequestHandle head(Context context, String url,
+			RequestParams params, ResponseHandlerInterface responseHandler,boolean openCache) {
+		return sendRequest(httpClient, httpContext, new HttpHead(
+				getUrlWithQueryString(isUrlEncodingEnabled, url, params)),
+				null, responseHandler, context,openCache);
+	}
+
+	/**
+	 * Perform a HTTP HEAD request and track the Android Context which initiated
+	 * the request with customized headers
+	 * 
+	 * @param context
+	 *            Context to execute request against
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set headers only for this request
+	 * @param params
+	 *            additional HEAD parameters to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle head(Context context, String url, Header[] headers,
+			RequestParams params, ResponseHandlerInterface responseHandler,boolean openCache) {
+		HttpUriRequest request = new HttpHead(getUrlWithQueryString(
+				isUrlEncodingEnabled, url, params));
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, null,
+				responseHandler, context,openCache);
+	}
+	public RequestHandle head(Context context, String url, Header[] headers,
+			RequestParams params, ResponseHandlerInterface responseHandler) {
+		HttpUriRequest request = new HttpHead(getUrlWithQueryString(
+				isUrlEncodingEnabled, url, params));
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, null,
+				responseHandler, context,false);
+	}
+	// [-] HTTP HEAD
+	// [+] HTTP GET
+
+	/**
+	 * Perform a HTTP GET request, without any parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle get(String url,
+			ResponseHandlerInterface responseHandler) {
+		return get(null, url, null, responseHandler,true);
+	}
+	public RequestHandle get(String url,
+			ResponseHandlerInterface responseHandler,boolean opencache) {
+		return get(null, url, null, responseHandler,opencache);
+	}
+	/**
+	 * Perform a HTTP GET request with parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional GET parameters to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 *@param openCache 
+	 *       is readCache data
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle get(String url, RequestParams params,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return get(null, url, params, responseHandler,openCache);
+	}
+	public RequestHandle get(String url, RequestParams params,
+			ResponseHandlerInterface responseHandler) {
+		return get(null, url, params, responseHandler,false);
+	}
+	/**
+	 * Perform a HTTP GET request without any parameters and track the Android
+	 * Context which initiated the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle get(Context context, String url,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return get(context, url, null, responseHandler,openCache);
+	}
+	public RequestHandle get(Context context, String url,
+			ResponseHandlerInterface responseHandler) {
+		return get(context, url, null, responseHandler,false);
+	}
+	/**
+	 * Perform a HTTP GET request and track the Android Context which initiated
+	 * the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional GET parameters to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle get(Context context, String url, RequestParams params,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+//		if (responseHandler instanceof FileAsyncHttpResponseHandler
+//				|| responseHandler instanceof DataAsyncHttpResponseHandler) {
+//			// 针对这两个地方不做缓存处理
+//		}
+		return sendRequest(httpClient, httpContext, new HttpGet(
+				getUrlWithQueryString(isUrlEncodingEnabled, url, params)),
+				null, responseHandler, context,openCache);
+	}
+
+	/**
+	 * Perform a HTTP GET request and track the Android Context which initiated
+	 * the request with customized headers
+	 * 
+	 * @param context
+	 *            Context to execute request against
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set headers only for this request
+	 * @param params
+	 *            additional GET parameters to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle get(Context context, String url, Header[] headers,
+			RequestParams params, ResponseHandlerInterface responseHandler,boolean openCache) {
+		HttpUriRequest request = new HttpGet(getUrlWithQueryString(
+				isUrlEncodingEnabled, url, params));
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, null,
+				responseHandler, context,openCache);
+	}
+	/**
+	 * Perform a HTTP GET request and track the Android Context which initiated
+	 * the request with customized headers
+	 * 
+	 * @param context
+	 *            Context to execute request against
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set headers only for this request
+	 * @param params
+	 *            additional GET parameters to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle get(Context context, String url, Header[] headers,
+			RequestParams params, ResponseHandlerInterface responseHandler) {
+		HttpUriRequest request = new HttpGet(getUrlWithQueryString(
+				isUrlEncodingEnabled, url, params));
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, null,
+				responseHandler, context,false);
+	}
+
+	// [-] HTTP GET
+	// [+] HTTP POST
+
+	/**
+	 * Perform a HTTP POST request, without any parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle post(String url,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return post(null, url, null, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP POST request with parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional POST parameters or files to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle post(String url, RequestParams params,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return post(null, url, params, responseHandler,openCache);
+	}
+	public RequestHandle post(String url, RequestParams params,
+			ResponseHandlerInterface responseHandler) {
+		return post(null, url, params, responseHandler,false);
+	}
+	/**
+	 * Perform a HTTP POST request and track the Android Context which initiated
+	 * the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional POST parameters or files to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle post(Context context, String url,
+			RequestParams params, ResponseHandlerInterface responseHandler,boolean openCache) {
+		return post(context, url, paramsToEntity(params, responseHandler),
+				null, responseHandler,openCache);
+	}
+	public RequestHandle post(Context context, String url,
+			RequestParams params, ResponseHandlerInterface responseHandler) {
+		return post(context, url, paramsToEntity(params, responseHandler),
+				null, responseHandler,false);
+	}
+	/**
+	 * Perform a HTTP POST request and track the Android Context which initiated
+	 * the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param entity
+	 *            a raw {@link org.apache.http.HttpEntity} to send with the
+	 *            request, for example, use this to send string/json/xml
+	 *            payloads to a server by passing a
+	 *            {@link org.apache.http.entity.StringEntity}.
+	 * @param contentType
+	 *            the content type of the payload you are sending, for example
+	 *            application/json if sending a json payload.
+	 * @param responseHandler
+	 *            the response ha ndler instance that should handle the
+	 *            response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle post(Context context, String url, HttpEntity entity,
+			String contentType, ResponseHandlerInterface responseHandler,boolean openCache) {
+		return sendRequest(
+				httpClient,
+				httpContext,
+				addEntityToRequestBase(
+						new HttpPost(URI.create(url).normalize()), entity),
+				contentType, responseHandler, context,openCache);
+	}
+
+	/**
+	 * Perform a HTTP POST request and track the Android Context which initiated
+	 * the request. Set headers only for this request
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set headers only for this request
+	 * @param params
+	 *            additional POST parameters to send with the request.
+	 * @param contentType
+	 *            the content type of the payload you are sending, for example
+	 *            application/json if sending a json payload.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle post(Context context, String url, Header[] headers,
+			RequestParams params, String contentType,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		HttpEntityEnclosingRequestBase request = new HttpPost(URI.create(url)
+				.normalize());
+		if (params != null)
+			request.setEntity(paramsToEntity(params, responseHandler));
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, contentType,
+				responseHandler, context,openCache);
+	}
+	public RequestHandle post(Context context, String url, Header[] headers,
+			RequestParams params, String contentType,
+			ResponseHandlerInterface responseHandler) {
+		HttpEntityEnclosingRequestBase request = new HttpPost(URI.create(url)
+				.normalize());
+		if (params != null)
+			request.setEntity(paramsToEntity(params, responseHandler));
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, contentType,
+				responseHandler, context,false);
+	}
+	/**
+	 * Perform a HTTP POST request and track the Android Context which initiated
+	 * the request. Set headers only for this request
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set headers only for this request
+	 * @param entity
+	 *            a raw {@link HttpEntity} to send with the request, for
+	 *            example, use this to send string/json/xml payloads to a server
+	 *            by passing a {@link org.apache.http.entity.StringEntity}.
+	 * @param contentType
+	 *            the content type of the payload you are sending, for example
+	 *            application/json if sending a json payload.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle post(Context context, String url, Header[] headers,
+			HttpEntity entity, String contentType,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		HttpEntityEnclosingRequestBase request = addEntityToRequestBase(
+				new HttpPost(URI.create(url).normalize()), entity);
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, contentType,
+				responseHandler, context,openCache);
+	}
+	public RequestHandle post(Context context, String url, Header[] headers,
+			HttpEntity entity, String contentType,
+			ResponseHandlerInterface responseHandler) {
+		HttpEntityEnclosingRequestBase request = addEntityToRequestBase(
+				new HttpPost(URI.create(url).normalize()), entity);
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, contentType,
+				responseHandler, context,false);
+	}
+	// [-] HTTP POST
+	// [+] HTTP PUT
+
+	/**
+	 * Perform a HTTP PUT request, without any parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle put(String url,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return put(null, url, null, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP PUT request with parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional PUT parameters or files to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle put(String url, RequestParams params,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return put(null, url, params, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP PUT request and track the Android Context which initiated
+	 * the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional PUT parameters or files to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle put(Context context, String url, RequestParams params,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return put(context, url, paramsToEntity(params, responseHandler), null,
+				responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP PUT request and track the Android Context which initiated
+	 * the request. And set one-time headers for the request
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param entity
+	 *            a raw {@link HttpEntity} to send with the request, for
+	 *            example, use this to send string/json/xml payloads to a server
+	 *            by passing a {@link org.apache.http.entity.StringEntity}.
+	 * @param contentType
+	 *            the content type of the payload you are sending, for example
+	 *            application/json if sending a json payload.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle put(Context context, String url, HttpEntity entity,
+			String contentType, ResponseHandlerInterface responseHandler,boolean openCache) {
+		return sendRequest(
+				httpClient,
+				httpContext,
+				addEntityToRequestBase(
+						new HttpPut(URI.create(url).normalize()), entity),
+				contentType, responseHandler, context,openCache);
+	}
+
+	/**
+	 * Perform a HTTP PUT request and track the Android Context which initiated
+	 * the request. And set one-time headers for the request
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set one-time headers for this request
+	 * @param entity
+	 *            a raw {@link HttpEntity} to send with the request, for
+	 *            example, use this to send string/json/xml payloads to a server
+	 *            by passing a {@link org.apache.http.entity.StringEntity}.
+	 * @param contentType
+	 *            the content type of the payload you are sending, for example
+	 *            application/json if sending a json payload.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle put(Context context, String url, Header[] headers,
+			HttpEntity entity, String contentType,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		HttpEntityEnclosingRequestBase request = addEntityToRequestBase(
+				new HttpPut(URI.create(url).normalize()), entity);
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, contentType,
+				responseHandler, context,openCache);
+	}
+	public RequestHandle put(Context context, String url, Header[] headers,
+			HttpEntity entity, String contentType,
+			ResponseHandlerInterface responseHandler) {
+		HttpEntityEnclosingRequestBase request = addEntityToRequestBase(
+				new HttpPut(URI.create(url).normalize()), entity);
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, contentType,
+				responseHandler, context,false);
+	}
+	/**
+	 * Perform a HTTP PATCH request, without any parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle patch(String url,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return patch(null, url, null, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP PATCH request with parameters.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional PUT parameters or files to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle patch(String url, RequestParams params,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return patch(null, url, params, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP PATCH request and track the Android Context which
+	 * initiated the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional PUT parameters or files to send with the request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle patch(Context context, String url,
+			RequestParams params, ResponseHandlerInterface responseHandler,boolean openCache) {
+		return patch(context, url, paramsToEntity(params, responseHandler),
+				null, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP PATCH request and track the Android Context which
+	 * initiated the request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle patch(Context context, String url, HttpEntity entity,
+			String contentType, ResponseHandlerInterface responseHandler,boolean openCache) {
+		return sendRequest(
+				httpClient,
+				httpContext,
+				addEntityToRequestBase(new HttpPatch(URI.create(url)
+						.normalize()), entity), contentType, responseHandler,
+				context,openCache);
+	}
+	public RequestHandle patch(Context context, String url, HttpEntity entity,
+			String contentType, ResponseHandlerInterface responseHandler) {
+		return sendRequest(
+				httpClient,
+				httpContext,
+				addEntityToRequestBase(new HttpPatch(URI.create(url)
+						.normalize()), entity), contentType, responseHandler,
+				context,false);
+	}
+	/**
+	 * Perform a HTTP PATCH request and track the Android Context which
+	 * initiated the request. And set one-time headers for the request
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set one-time headers for this request
+	 * @param entity
+	 *            a raw {@link HttpEntity} to send with the request, for
+	 *            example, use this to send string/json/xml payloads to a server
+	 *            by passing a {@link org.apache.http.entity.StringEntity}.
+	 * @param contentType
+	 *            the content type of the payload you are sending, for example
+	 *            application/json if sending a json payload.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle patch(Context context, String url, Header[] headers,
+			HttpEntity entity, String contentType,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		HttpEntityEnclosingRequestBase request = addEntityToRequestBase(
+				new HttpPatch(URI.create(url).normalize()), entity);
+		if (headers != null)
+			request.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, request, contentType,
+				responseHandler, context,openCache);
+	}
+
+	// [-] HTTP PUT
+	// [+] HTTP DELETE
+
+	/**
+	 * Perform a HTTP DELETE request.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle delete(String url,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		return delete(null, url, responseHandler,openCache);
+	}
+
+	/**
+	 * Perform a HTTP DELETE request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle delete(Context context, String url,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		final HttpDelete delete = new HttpDelete(URI.create(url).normalize());
+		return sendRequest(httpClient, httpContext, delete, null,
+				responseHandler, context,openCache);
+	}
+
+	/**
+	 * Perform a HTTP DELETE request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set one-time headers for this request
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle delete(Context context, String url, Header[] headers,
+			ResponseHandlerInterface responseHandler,boolean openCache) {
+		final HttpDelete delete = new HttpDelete(URI.create(url).normalize());
+		if (headers != null)
+			delete.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, delete, null,
+				responseHandler, context,openCache);
+	}
+
+	/**
+	 * Perform a HTTP DELETE request.
+	 * 
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param params
+	 *            additional DELETE parameters or files to send with the
+	 *            request.
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 */
+	public void delete(String url, RequestParams params,
+			AsyncHttpResponseHandler responseHandler,boolean openCache) {
+		final HttpDelete delete = new HttpDelete(getUrlWithQueryString(
+				isUrlEncodingEnabled, url, params));
+		sendRequest(httpClient, httpContext, delete, null, responseHandler,
+				null,openCache);
+	}
+
+	/**
+	 * Perform a HTTP DELETE request.
+	 * 
+	 * @param context
+	 *            the Android Context which initiated the request.
+	 * @param url
+	 *            the URL to send the request to.
+	 * @param headers
+	 *            set one-time headers for this request
+	 * @param params
+	 *            additional DELETE parameters or files to send along with
+	 *            request
+	 * @param responseHandler
+	 *            the response handler instance that should handle the response.
+	 * @return RequestHandle of future request process
+	 */
+	public RequestHandle delete(Context context, String url, Header[] headers,
+			RequestParams params, ResponseHandlerInterface responseHandler,boolean openCache) {
+		HttpDelete httpDelete = new HttpDelete(getUrlWithQueryString(
+				isUrlEncodingEnabled, url, params));
+		if (headers != null)
+			httpDelete.setHeaders(headers);
+		return sendRequest(httpClient, httpContext, httpDelete, null,
+				responseHandler, context,openCache);
+	}
+
+	// [-] HTTP DELETE
+
+	/**
+	 * Instantiate a new asynchronous HTTP request for the passed parameters.
+	 * 
+	 * @param client
+	 *            HttpClient to be used for request, can differ in single
+	 *            requests
+	 * @param contentType
+	 *            MIME body type, for POST and PUT requests, may be null
+	 * @param context
+	 *            Context of Android application, to hold the reference of
+	 *            request
+	 * @param httpContext
+	 *            HttpContext in which the request will be executed
+	 * @param responseHandler
+	 *            ResponseHandler or its subclass to put the response into
+	 * @param uriRequest
+	 *            instance of HttpUriRequest, which means it must be of
+	 *            HttpDelete, HttpPost, HttpGet, HttpPut, etc.
+	 * @return AsyncHttpRequest ready to be dispatched
+	 */
+	protected AsyncHttpRequest newAsyncHttpRequest(DefaultHttpClient client,
+			HttpContext httpContext, HttpUriRequest uriRequest,
+			String contentType, ResponseHandlerInterface responseHandler,
+			Context context,boolean openCache) {
+		return new AsyncHttpRequest(client, httpContext, uriRequest,
+				responseHandler,openCache);
+	}
+	protected AsyncHttpRequest newAsyncHttpRequest(DefaultHttpClient client,
+			HttpContext httpContext, HttpUriRequest uriRequest,
+			String contentType, ResponseHandlerInterface responseHandler,
+			Context context) {
+		return new AsyncHttpRequest(client, httpContext, uriRequest,
+				responseHandler);
+	}
+
+	/**
+	 * Puts a new request in queue as a new thread in pool to be executed
+	 * 
+	 * @param client
+	 *            HttpClient to be used for request, can differ in single
+	 *            requests
+	 * @param contentType
+	 *            MIME body type, for POST and PUT requests, may be null
+	 * @param context
+	 *            Context of Android application, to hold the reference of
+	 *            request
+	 * @param httpContext
+	 *            HttpContext in which the request will be executed
+	 * @param responseHandler
+	 *            ResponseHandler or its subclass to put the response into
+	 * @param uriRequest
+	 *            instance of HttpUriRequest, which means it must be of
+	 *            HttpDelete, HttpPost, HttpGet, HttpPut, etc.
+	 * @return RequestHandle of future request process
+	 */
+	protected RequestHandle sendRequest(DefaultHttpClient client,
+			HttpContext httpContext, HttpUriRequest uriRequest,
+			String contentType, ResponseHandlerInterface responseHandler,
+			Context context,boolean openCache) {
+		if (uriRequest == null) {
+			throw new IllegalArgumentException(
+					"HttpUriRequest must not be null");
+		}
+		if(DEBUG)
+			Log.i("HTML", uriRequest.getURI().toASCIIString());
+		if (responseHandler == null) {
+			throw new IllegalArgumentException(
+					"ResponseHandler must not be null");
+		}
+
+		if (responseHandler.getUseSynchronousMode()
+				&& !responseHandler.getUsePoolThread()) {
+			throw new IllegalArgumentException(
+					"Synchronous ResponseHandler used in AsyncHttpClient. You should create your response handler in a looper thread or use SyncHttpClient instead.");
+		}
+
+		if (contentType != null) {
+			if (uriRequest instanceof HttpEntityEnclosingRequestBase
+					&& ((HttpEntityEnclosingRequestBase) uriRequest)
+							.getEntity() != null) {
+				Log.w(LOG_TAG,
+						"Passed contentType will be ignored because HttpEntity sets content type");
+			} else {
+				uriRequest.setHeader(HEADER_CONTENT_TYPE, contentType);
+			}
+		}
+
+		responseHandler.setRequestHeaders(uriRequest.getAllHeaders());
+		responseHandler.setRequestURI(uriRequest.getURI());
+		responseHandler.setOpenCache(openCache);
+		AsyncHttpRequest request = newAsyncHttpRequest(client, httpContext,
+				uriRequest, contentType, responseHandler, context,openCache);
+		threadPool.submit(request);
+		RequestHandle requestHandle = new RequestHandle(request);
+
+		if (context != null) {
+			// Add request to request map
+			List<RequestHandle> requestList = requestMap.get(context);
+			synchronized (requestMap) {
+				if (requestList == null) {
+					requestList = Collections
+							.synchronizedList(new LinkedList<RequestHandle>());
+					requestMap.put(context, requestList);
+				}
+			}
+
+			requestList.add(requestHandle);
+
+			Iterator<RequestHandle> iterator = requestList.iterator();
+			while (iterator.hasNext()) {
+				if (iterator.next().shouldBeGarbageCollected()) {
+					iterator.remove();
+				}
+			}
+		}
+
+		return requestHandle;
+	}
+
+	/**
+	 * Sets state of URL encoding feature, see bug #227, this method allows you
+	 * to turn off and on this auto-magic feature on-demand.
+	 * 
+	 * @param enabled
+	 *            desired state of feature
+	 */
+	public void setURLEncodingEnabled(boolean enabled) {
+		this.isUrlEncodingEnabled = enabled;
+	}
+
+	/**
+	 * Will encode url, if not disabled, and adds params on the end of it
+	 * 
+	 * @param url
+	 *            String with URL, should be valid URL without params
+	 * @param params
+	 *            RequestParams to be appended on the end of URL
+	 * @param shouldEncodeUrl
+	 *            whether url should be encoded (replaces spaces with %20)
+	 * @return encoded url if requested with params appended if any available
+	 */
+	public static String getUrlWithQueryString(boolean shouldEncodeUrl,
+			String url, RequestParams params) {
+		if (url == null)
+			return null;
+
+		if (shouldEncodeUrl) {
+			try {
+				String decodedURL = URLDecoder.decode(url, "UTF-8");
+				URL _url = new URL(decodedURL);
+				URI _uri = new URI(_url.getProtocol(), _url.getUserInfo(),
+						_url.getHost(), _url.getPort(), _url.getPath(),
+						_url.getQuery(), _url.getRef());
+				url = _uri.toASCIIString();
+			} catch (Exception ex) {
+				// Should not really happen, added just for sake of validity
+				Log.e(LOG_TAG, "getUrlWithQueryString encoding URL", ex);
+			}
+		}
+
+		if (params != null) {
+			// Construct the query string and trim it, in case it
+			// includes any excessive white spaces.
+			String paramString = params.getParamString().trim();
+
+			// Only add the query string if it isn't empty and it
+			// isn't equal to '?'.
+			if (!paramString.equals("") && !paramString.equals("?")) {
+				url += url.contains("?") ? "&" : "?";
+				url += paramString;
+			}
+		}
+
+		return url;
+	}
+
+	/**
+	 * Checks the InputStream if it contains GZIP compressed data
+	 * 
+	 * @param inputStream
+	 *            InputStream to be checked
+	 * @return true or false if the stream contains GZIP compressed data
+	 * @throws java.io.IOException
+	 */
+	public static boolean isInputStreamGZIPCompressed(
+			final PushbackInputStream inputStream) throws IOException {
+		if (inputStream == null)
+			return false;
+
+		byte[] signature = new byte[2];
+		int readStatus = inputStream.read(signature);
+		inputStream.unread(signature);
+		int streamHeader = ((int) signature[0] & 0xff)
+				| ((signature[1] << 8) & 0xff00);
+		return readStatus == 2 && GZIPInputStream.GZIP_MAGIC == streamHeader;
+	}
+
+	/**
+	 * A utility function to close an input stream without raising an exception.
+	 * 
+	 * @param is
+	 *            input stream to close safely
+	 */
+	public static void silentCloseInputStream(InputStream is) {
+		try {
+			if (is != null) {
+				is.close();
+			}
+		} catch (IOException e) {
+			Log.w(LOG_TAG, "Cannot close input stream", e);
+		}
+	}
+
+	/**
+	 * A utility function to close an output stream without raising an
+	 * exception.
+	 * 
+	 * @param os
+	 *            output stream to close safely
+	 */
+	public static void silentCloseOutputStream(OutputStream os) {
+		try {
+			if (os != null) {
+				os.close();
+			}
+		} catch (IOException e) {
+			Log.w(LOG_TAG, "Cannot close output stream", e);
+		}
+	}
+
+	/**
+	 * Returns HttpEntity containing data from RequestParams included with
+	 * request declaration. Allows also passing progress from upload via
+	 * provided ResponseHandler
+	 * 
+	 * @param params
+	 *            additional request params
+	 * @param responseHandler
+	 *            ResponseHandlerInterface or its subclass to be notified on
+	 *            progress
+	 */
+	private HttpEntity paramsToEntity(RequestParams params,
+			ResponseHandlerInterface responseHandler) {
+		HttpEntity entity = null;
+
+		try {
+			if (params != null) {
+				entity = params.getEntity(responseHandler);
+			}
+		} catch (IOException e) {
+			if (responseHandler != null) {
+				responseHandler.sendFailureMessage(0, null, null, e);
+			} else {
+				e.printStackTrace();
+			}
+		}
+
+		return entity;
+	}
+
+	public boolean isUrlEncodingEnabled() {
+		return isUrlEncodingEnabled;
+	}
+
+	/**
+	 * Applicable only to HttpRequest methods extending
+	 * HttpEntityEnclosingRequestBase, which is for example not DELETE
+	 * 
+	 * @param entity
+	 *            entity to be included within the request
+	 * @param requestBase
+	 *            HttpRequest instance, must not be null
+	 */
+	private HttpEntityEnclosingRequestBase addEntityToRequestBase(
+			HttpEntityEnclosingRequestBase requestBase, HttpEntity entity) {
+		if (entity != null) {
+			requestBase.setEntity(entity);
+		}
+
+		return requestBase;
+	}
+
+	/**
+	 * This horrible hack is required on Android, due to implementation of
+	 * BasicManagedEntity, which doesn't chain call consumeContent on underlying
+	 * wrapped HttpEntity
+	 * 
+	 * @param entity
+	 *            HttpEntity, may be null
+	 */
+	public static void endEntityViaReflection(HttpEntity entity) {
+		if (entity instanceof HttpEntityWrapper) {
+			try {
+				Field f = null;
+				Field[] fields = HttpEntityWrapper.class.getDeclaredFields();
+				for (Field ff : fields) {
+					if (ff.getName().equals("wrappedEntity")) {
+						f = ff;
+						break;
+					}
+				}
+				if (f != null) {
+					f.setAccessible(true);
+					HttpEntity wrapped = (HttpEntity) f.get(entity);
+					if (wrapped != null) {
+						wrapped.consumeContent();
+					}
+				}
+			} catch (Throwable t) {
+				Log.e(LOG_TAG, "wrappedEntity consume", t);
+			}
+		}
+	}
+
+	/**
+	 * Enclosing entity to hold stream of gzip decoded data for accessing
+	 * HttpEntity contents
+	 */
+	private static class InflatingEntity extends HttpEntityWrapper {
+
+		public InflatingEntity(HttpEntity wrapped) {
+			super(wrapped);
+		}
+
+		InputStream wrappedStream;
+		PushbackInputStream pushbackStream;
+		GZIPInputStream gzippedStream;
+
+		@Override
+		public InputStream getContent() throws IOException {
+			wrappedStream = wrappedEntity.getContent();
+			pushbackStream = new PushbackInputStream(wrappedStream, 2);
+			if (isInputStreamGZIPCompressed(pushbackStream)) {
+				gzippedStream = new GZIPInputStream(pushbackStream);
+				return gzippedStream;
+			} else {
+				return pushbackStream;
+			}
+		}
+
+		@Override
+		public long getContentLength() {
+			return wrappedEntity == null ? 0 : wrappedEntity.getContentLength();
+		}
+
+		@Override
+		public void consumeContent() throws IOException {
+			AsyncHttpClient.silentCloseInputStream(wrappedStream);
+			AsyncHttpClient.silentCloseInputStream(pushbackStream);
+			AsyncHttpClient.silentCloseInputStream(gzippedStream);
+			super.consumeContent();
+		}
+	}
 }

--- a/library/src/main/java/com/loopj/android/http/AsyncHttpRequest.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpRequest.java
@@ -14,7 +14,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.loopj.android.http;
 
@@ -26,6 +26,8 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.AbstractHttpClient;
 import org.apache.http.protocol.HttpContext;
 
+import com.loopj.android.http.Cache.Entry;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
@@ -35,205 +37,230 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Internal class, representing the HttpRequest, done in asynchronous manner
  */
 public class AsyncHttpRequest implements Runnable {
-    private final AbstractHttpClient client;
-    private final HttpContext context;
-    private final HttpUriRequest request;
-    private final ResponseHandlerInterface responseHandler;
-    private int executionCount;
-    private final AtomicBoolean isCancelled = new AtomicBoolean();
-    private boolean cancelIsNotified;
-    private volatile boolean isFinished;
-    private boolean isRequestPreProcessed;
+	private final AbstractHttpClient client;
+	private final HttpContext context;
+	private final HttpUriRequest request;
+	private final ResponseHandlerInterface responseHandler;
+	private int executionCount;
+	private final AtomicBoolean isCancelled = new AtomicBoolean();
+	private boolean cancelIsNotified;
+	private volatile boolean isFinished;
+	private boolean isRequestPreProcessed;
+	private boolean openCache = false;
 
-    public AsyncHttpRequest(AbstractHttpClient client, HttpContext context, HttpUriRequest request, ResponseHandlerInterface responseHandler) {
-        this.client = Utils.notNull(client, "client");
-        this.context = Utils.notNull(context, "context");
-        this.request = Utils.notNull(request, "request");
-        this.responseHandler = Utils.notNull(responseHandler, "responseHandler");
-    }
+	public AsyncHttpRequest(AbstractHttpClient client, HttpContext context,
+			HttpUriRequest request, ResponseHandlerInterface responseHandler) {
+		this.client = Utils.notNull(client, "client");
+		this.context = Utils.notNull(context, "context");
+		this.request = Utils.notNull(request, "request");
+		this.responseHandler = Utils
+				.notNull(responseHandler, "responseHandler");
+	}
 
-    /**
-     * This method is called once by the system when the request is about to be
-     * processed by the system. The library makes sure that a single request
-     * is pre-processed only once.
-     *
-     * Please note: pre-processing does NOT run on the main thread, and thus
-     * any UI activities that you must perform should be properly dispatched to
-     * the app's UI thread.
-     *
-     * @param request The request to pre-process
-     */
-    public void onPreProcessRequest(AsyncHttpRequest request) {
-        // default action is to do nothing...
-    }
+	public AsyncHttpRequest(AbstractHttpClient client, HttpContext context,
+			HttpUriRequest request, ResponseHandlerInterface responseHandler,
+			boolean openCache) {
+		this.openCache = openCache;
+		this.client = Utils.notNull(client, "client");
+		this.context = Utils.notNull(context, "context");
+		this.request = Utils.notNull(request, "request");
+		this.responseHandler = Utils
+				.notNull(responseHandler, "responseHandler");
+	}
 
-    /**
-     * This method is called once by the system when the request has been fully
-     * sent, handled and finished. The library makes sure that a single request
-     * is post-processed only once.
-     *
-     * Please note: post-processing does NOT run on the main thread, and thus
-     * any UI activities that you must perform should be properly dispatched to
-     * the app's UI thread.
-     *
-     * @param request The request to post-process
-     */
-    public void onPostProcessRequest(AsyncHttpRequest request) {
-        // default action is to do nothing...
-    }
+	/**
+	 * This method is called once by the system when the request is about to be
+	 * processed by the system. The library makes sure that a single request is
+	 * pre-processed only once.
+	 * 
+	 * Please note: pre-processing does NOT run on the main thread, and thus any
+	 * UI activities that you must perform should be properly dispatched to the
+	 * app's UI thread.
+	 * 
+	 * @param request
+	 *            The request to pre-process
+	 */
+	public void onPreProcessRequest(AsyncHttpRequest request) {
+		// default action is to do nothing...
+	}
 
-    @Override
-    public void run() {
-        if (isCancelled()) {
-            return;
-        }
+	/**
+	 * This method is called once by the system when the request has been fully
+	 * sent, handled and finished. The library makes sure that a single request
+	 * is post-processed only once.
+	 * 
+	 * Please note: post-processing does NOT run on the main thread, and thus
+	 * any UI activities that you must perform should be properly dispatched to
+	 * the app's UI thread.
+	 * 
+	 * @param request
+	 *            The request to post-process
+	 */
+	public void onPostProcessRequest(AsyncHttpRequest request) {
+		// default action is to do nothing...
+	}
 
-        // Carry out pre-processing for this request only once.
-        if (!isRequestPreProcessed) {
-            isRequestPreProcessed = true;
-            onPreProcessRequest(this);
-        }
+	@Override
+	public void run() {
+		if (isCancelled()) {
+			return;
+		}
 
-        if (isCancelled()) {
-            return;
-        }
+		// Carry out pre-processing for this request only once.
+		if (!isRequestPreProcessed) {
+			isRequestPreProcessed = true;
+			onPreProcessRequest(this);
+		}
 
-        responseHandler.sendStartMessage();
+		if (isCancelled()) {
+			return;
+		}
 
-        if (isCancelled()) {
-            return;
-        }
+		responseHandler.sendStartMessage();
 
-        try {
-            makeRequestWithRetries();
-        } catch (IOException e) {
-            if (!isCancelled()) {
-                responseHandler.sendFailureMessage(0, null, null, e);
-            } else {
-                Log.e("AsyncHttpRequest", "makeRequestWithRetries returned error", e);
-            }
-        }
+		if (isCancelled()) {
+			return;
+		}
+		try {
+			makeRequestWithRetries();
+		} catch (IOException e) {
+			if (!isCancelled()) {
+				if (openCache) {
+					// request error,if openCache=true findByCache content.
+					Entry entryCache = DiskBasedCache.getCache().get(
+							request.getURI().toASCIIString());
+					if (entryCache != null)
+						responseHandler.sendSuccessMessage(200, null,
+								entryCache.data);
+				} else
+					responseHandler.sendFailureMessage(0, null, null, e);
+			} else {
+				Log.e("AsyncHttpRequest",
+						"makeRequestWithRetries returned error", e);
+			}
+		}
 
-        if (isCancelled()) {
-            return;
-        }
+		if (isCancelled()) {
+			return;
+		}
 
-        responseHandler.sendFinishMessage();
+		responseHandler.sendFinishMessage();
 
-        if (isCancelled()) {
-            return;
-        }
+		if (isCancelled()) {
+			return;
+		}
 
-        // Carry out post-processing for this request.
-        onPostProcessRequest(this);
+		// Carry out post-processing for this request.
+		onPostProcessRequest(this);
 
-        isFinished = true;
-    }
+		isFinished = true;
+	}
 
-    private void makeRequest() throws IOException {
-        if (isCancelled()) {
-            return;
-        }
+	private void makeRequest() throws IOException {
+		if (isCancelled()) {
+			return;
+		}
 
-        // Fixes #115
-        if (request.getURI().getScheme() == null) {
-            // subclass of IOException so processed in the caller
-            throw new MalformedURLException("No valid URI scheme was provided");
-        }
+		// Fixes #115
+		if (request.getURI().getScheme() == null) {
+			// subclass of IOException so processed in the caller
+			throw new MalformedURLException("No valid URI scheme was provided");
+		}
 
-        if (responseHandler instanceof RangeFileAsyncHttpResponseHandler) {
-            ((RangeFileAsyncHttpResponseHandler) responseHandler).updateRequestHeaders(request);
-        }
+		if (responseHandler instanceof RangeFileAsyncHttpResponseHandler) {
+			((RangeFileAsyncHttpResponseHandler) responseHandler)
+					.updateRequestHeaders(request);
+		}
 
-        HttpResponse response = client.execute(request, context);
+		HttpResponse response = client.execute(request, context);
 
-        if (isCancelled()) {
-            return;
-        }
+		if (isCancelled()) {
+			return;
+		}
 
-        // Carry out pre-processing for this response.
-        responseHandler.onPreProcessResponse(responseHandler, response);
+		// Carry out pre-processing for this response.
+		responseHandler.onPreProcessResponse(responseHandler, response);
 
-        if (isCancelled()) {
-            return;
-        }
+		if (isCancelled()) {
+			return;
+		}
 
-        // The response is ready, handle it.
-        responseHandler.sendResponseMessage(response);
+		// The response is ready, handle it.
+		responseHandler.sendResponseMessage(response);
 
-        if (isCancelled()) {
-            return;
-        }
+		if (isCancelled()) {
+			return;
+		}
 
-        // Carry out post-processing for this response.
-        responseHandler.onPostProcessResponse(responseHandler, response);
-    }
+		// Carry out post-processing for this response.
+		responseHandler.onPostProcessResponse(responseHandler, response);
+	}
 
-    private void makeRequestWithRetries() throws IOException {
-        boolean retry = true;
-        IOException cause = null;
-        HttpRequestRetryHandler retryHandler = client.getHttpRequestRetryHandler();
-        try {
-            while (retry) {
-                try {
-                    makeRequest();
-                    return;
-                } catch (UnknownHostException e) {
-                    // switching between WI-FI and mobile data networks can cause a retry which then results in an UnknownHostException
-                    // while the WI-FI is initialising. The retry logic will be invoked here, if this is NOT the first retry
-                    // (to assist in genuine cases of unknown host) which seems better than outright failure
-                    cause = new IOException("UnknownHostException exception: " + e.getMessage());
-                    retry = (executionCount > 0) && retryHandler.retryRequest(cause, ++executionCount, context);
-                } catch (NullPointerException e) {
-                    // there's a bug in HttpClient 4.0.x that on some occasions causes
-                    // DefaultRequestExecutor to throw an NPE, see
-                    // http://code.google.com/p/android/issues/detail?id=5255
-                    cause = new IOException("NPE in HttpClient: " + e.getMessage());
-                    retry = retryHandler.retryRequest(cause, ++executionCount, context);
-                } catch (IOException e) {
-                    if (isCancelled()) {
-                        // Eating exception, as the request was cancelled
-                        return;
-                    }
-                    cause = e;
-                    retry = retryHandler.retryRequest(cause, ++executionCount, context);
-                }
-                if (retry) {
-                    responseHandler.sendRetryMessage(executionCount);
-                }
-            }
-        } catch (Exception e) {
-            // catch anything else to ensure failure message is propagated
-            Log.e("AsyncHttpRequest", "Unhandled exception origin cause", e);
-            cause = new IOException("Unhandled exception: " + e.getMessage());
-        }
+	private void makeRequestWithRetries() throws IOException {
+		boolean retry = true;
+		IOException cause = null;
+		HttpRequestRetryHandler retryHandler = client
+				.getHttpRequestRetryHandler();
+		try {
+			while (retry) {
+				try {
+					makeRequest();
+					return;
+				} catch (UnknownHostException e) {
+					cause = new IOException("UnknownHostException exception: "
+							+ e.getMessage());
+					retry = (executionCount > 0)
+							&& retryHandler.retryRequest(cause,
+									++executionCount, context);
+				} catch (NullPointerException e) {
+					cause = new IOException("NPE in HttpClient: "
+							+ e.getMessage());
+					retry = retryHandler.retryRequest(cause, ++executionCount,
+							context);
+				} catch (IOException e) {
+					if (isCancelled()) {
+						return;
+					}
+					cause = e;
+					retry = retryHandler.retryRequest(cause, ++executionCount,
+							context);
+				}
+				if (retry) {
+					responseHandler.sendRetryMessage(executionCount);
+				}
+			}
+		} catch (Exception e) {
+			// catch anything else to ensure failure message is propagated
+			Log.e("AsyncHttpRequest", "Unhandled exception origin cause", e);
+			cause = new IOException("Unhandled exception: " + e.getMessage());
+		}
 
-        // cleaned up to throw IOException
-        throw (cause);
-    }
+		// cleaned up to throw IOException
+		throw (cause);
+	}
 
-    public boolean isCancelled() {
-        boolean cancelled = isCancelled.get();
-        if (cancelled) {
-            sendCancelNotification();
-        }
-        return cancelled;
-    }
+	public boolean isCancelled() {
+		boolean cancelled = isCancelled.get();
+		if (cancelled) {
+			sendCancelNotification();
+		}
+		return cancelled;
+	}
 
-    private synchronized void sendCancelNotification() {
-        if (!isFinished && isCancelled.get() && !cancelIsNotified) {
-            cancelIsNotified = true;
-            responseHandler.sendCancelMessage();
-        }
-    }
+	private synchronized void sendCancelNotification() {
+		if (!isFinished && isCancelled.get() && !cancelIsNotified) {
+			cancelIsNotified = true;
+			responseHandler.sendCancelMessage();
+		}
+	}
 
-    public boolean isDone() {
-        return isCancelled() || isFinished;
-    }
+	public boolean isDone() {
+		return isCancelled() || isFinished;
+	}
 
-    public boolean cancel(boolean mayInterruptIfRunning) {
-        isCancelled.set(true);
-        request.abort();
-        return isCancelled();
-    }
+	public boolean cancel(boolean mayInterruptIfRunning) {
+		isCancelled.set(true);
+		request.abort();
+		return isCancelled();
+	}
 }

--- a/library/src/main/java/com/loopj/android/http/AsyncHttpResponseHandler.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpResponseHandler.java
@@ -14,14 +14,13 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.loopj.android.http;
 
-import android.os.Handler;
-import android.os.Looper;
-import android.os.Message;
-import android.util.Log;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -30,466 +29,599 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.util.ByteArrayBuffer;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
+import com.loopj.android.http.Cache.Entry;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.util.Log;
 
 /**
- * Used to intercept and handle the responses from requests made using {@link AsyncHttpClient}. The
- * {@link #onSuccess(int, org.apache.http.Header[], byte[])} method is designed to be anonymously
- * overridden with your own response handling code. <p>&nbsp;</p> Additionally, you can override the
- * {@link #onFailure(int, org.apache.http.Header[], byte[], Throwable)}, {@link #onStart()}, {@link
- * #onFinish()}, {@link #onRetry(int)} and {@link #onProgress(int, int)} methods as required.
- * <p>&nbsp;</p> For example: <p>&nbsp;</p>
+ * Used to intercept and handle the responses from requests made using
+ * {@link AsyncHttpClient}. The
+ * {@link #onSuccess(int, org.apache.http.Header[], byte[])} method is designed
+ * to be anonymously overridden with your own response handling code.
+ * <p>
+ * &nbsp;
+ * </p>
+ * Additionally, you can override the
+ * {@link #onFailure(int, org.apache.http.Header[], byte[], Throwable)},
+ * {@link #onStart()}, {@link #onFinish()}, {@link #onRetry(int)} and
+ * {@link #onProgress(int, int)} methods as required.
+ * <p>
+ * &nbsp;
+ * </p>
+ * For example:
+ * <p>
+ * &nbsp;
+ * </p>
+ * 
  * <pre>
  * AsyncHttpClient client = new AsyncHttpClient();
- * client.get("http://www.google.com", new AsyncHttpResponseHandler() {
- *     &#064;Override
- *     public void onStart() {
- *         // Initiated the request
- *     }
- *
- *     &#064;Override
- *     public void onSuccess(int statusCode, Header[] headers, byte[] responseBody) {
- *         // Successfully got a response
- *     }
- *
- *     &#064;Override
- *     public void onFailure(int statusCode, Header[] headers, byte[] responseBody, Throwable
- * error)
- * {
- *         // Response failed :(
- *     }
- *
- *     &#064;Override
- *     public void onRetry(int retryNo) {
- *         // Request was retried
- *     }
- *
- *     &#064;Override
- *     public void onProgress(int bytesWritten, int totalSize) {
- *         // Progress notification
- *     }
- *
- *     &#064;Override
- *     public void onFinish() {
- *         // Completed the request (either success or failure)
- *     }
+ * client.get(&quot;http://www.google.com&quot;, new AsyncHttpResponseHandler() {
+ * 	&#064;Override
+ * 	public void onStart() {
+ * 		// Initiated the request
+ * 	}
+ * 
+ * 	&#064;Override
+ * 	public void onSuccess(int statusCode, Header[] headers, byte[] responseBody) {
+ * 		// Successfully got a response
+ * 	}
+ * 
+ * 	&#064;Override
+ * 	public void onFailure(int statusCode, Header[] headers,
+ * 			byte[] responseBody, Throwable error) {
+ * 		// Response failed :(
+ * 	}
+ * 
+ * 	&#064;Override
+ * 	public void onRetry(int retryNo) {
+ * 		// Request was retried
+ * 	}
+ * 
+ * 	&#064;Override
+ * 	public void onProgress(int bytesWritten, int totalSize) {
+ * 		// Progress notification
+ * 	}
+ * 
+ * 	&#064;Override
+ * 	public void onFinish() {
+ * 		// Completed the request (either success or failure)
+ * 	}
  * });
  * </pre>
  */
-public abstract class AsyncHttpResponseHandler implements ResponseHandlerInterface {
+public abstract class AsyncHttpResponseHandler implements
+		ResponseHandlerInterface {
 
-    private static final String LOG_TAG = "AsyncHttpResponseHandler";
+	private static final String LOG_TAG = "AsyncHttpResponseHandler";
 
-    protected static final int SUCCESS_MESSAGE = 0;
-    protected static final int FAILURE_MESSAGE = 1;
-    protected static final int START_MESSAGE = 2;
-    protected static final int FINISH_MESSAGE = 3;
-    protected static final int PROGRESS_MESSAGE = 4;
-    protected static final int RETRY_MESSAGE = 5;
-    protected static final int CANCEL_MESSAGE = 6;
+	protected static final int SUCCESS_MESSAGE = 0;
+	protected static final int FAILURE_MESSAGE = 1;
+	protected static final int START_MESSAGE = 2;
+	protected static final int FINISH_MESSAGE = 3;
+	protected static final int PROGRESS_MESSAGE = 4;
+	protected static final int RETRY_MESSAGE = 5;
+	protected static final int CANCEL_MESSAGE = 6;
 
-    protected static final int BUFFER_SIZE = 4096;
+	protected static final int BUFFER_SIZE = 4096;
 
-    public static final String DEFAULT_CHARSET = "UTF-8";
-    public static final String UTF8_BOM = "\uFEFF";
-    private String responseCharset = DEFAULT_CHARSET;
-    private Handler handler;
-    private boolean useSynchronousMode;
-    private boolean usePoolThread;
+	public static final String DEFAULT_CHARSET = "UTF-8";
+	public static final String UTF8_BOM = "\uFEFF";
+	private String responseCharset = DEFAULT_CHARSET;
+	private Handler handler;
+	private boolean useSynchronousMode;
+	private boolean usePoolThread;
 
-    private URI requestURI = null;
-    private Header[] requestHeaders = null;
-    private Looper looper = null;
+	private URI requestURI = null;
+	private Header[] requestHeaders = null;
+	private Looper looper = null;
+	private boolean isCache=true;
+	/**
+	 * Creates a new AsyncHttpResponseHandler
+	 */
+	public AsyncHttpResponseHandler() {
+		this(null);
+	}
 
-    /**
-     * Creates a new AsyncHttpResponseHandler
-     */
-    public AsyncHttpResponseHandler() {
-        this(null);
-    }
+	/**
+	 * Creates a new AsyncHttpResponseHandler with a user-supplied looper. If
+	 * the passed looper is null, the looper attached to the current thread will
+	 * be used.
+	 * 
+	 * @param looper
+	 *            The looper to work with
+	 */
+	public AsyncHttpResponseHandler(Looper looper) {
+		this.looper = looper == null ? Looper.myLooper() : looper;
 
-    /**
-     * Creates a new AsyncHttpResponseHandler with a user-supplied looper. If
-     * the passed looper is null, the looper attached to the current thread will
-     * be used.
-     *
-     * @param looper The looper to work with
-     */
-    public AsyncHttpResponseHandler(Looper looper) {
-        this.looper = looper == null ? Looper.myLooper() : looper;
+		// Use asynchronous mode by default.
+		setUseSynchronousMode(false);
 
-        // Use asynchronous mode by default.
-        setUseSynchronousMode(false);
+		// Do not use the pool's thread to fire callbacks by default.
+		setUsePoolThread(false);
+	}
 
-        // Do not use the pool's thread to fire callbacks by default.
-        setUsePoolThread(false);
-    }
+	/**
+	 * Creates a new AsyncHttpResponseHandler and decide whether the callbacks
+	 * will be fired on current thread's looper or the pool thread's.
+	 * 
+	 * @param usePoolThread
+	 *            Whether to use the pool's thread to fire callbacks
+	 */
+	public AsyncHttpResponseHandler(boolean usePoolThread) {
+		// Whether to use the pool's thread to fire callbacks.
+		setUsePoolThread(usePoolThread);
 
-    /**
-     * Creates a new AsyncHttpResponseHandler and decide whether the callbacks
-     * will be fired on current thread's looper or the pool thread's.
-     *
-     * @param usePoolThread Whether to use the pool's thread to fire callbacks
-     */
-    public AsyncHttpResponseHandler(boolean usePoolThread) {
-        // Whether to use the pool's thread to fire callbacks.
-        setUsePoolThread(usePoolThread);
+		// When using the pool's thread, there's no sense in having a looper.
+		if (!getUsePoolThread()) {
+			// Use the current thread's looper.
+			this.looper = Looper.myLooper();
 
-        // When using the pool's thread, there's no sense in having a looper.
-        if (!getUsePoolThread()) {
-            // Use the current thread's looper.
-            this.looper = Looper.myLooper();
+			// Use asynchronous mode by default.
+			setUseSynchronousMode(false);
+		}
+	}
 
-            // Use asynchronous mode by default.
-            setUseSynchronousMode(false);
-        }
-    }
+	@Override
+	public URI getRequestURI() {
+		return this.requestURI;
+	}
 
-    @Override
-    public URI getRequestURI() {
-        return this.requestURI;
-    }
+	@Override
+	public Header[] getRequestHeaders() {
+		return this.requestHeaders;
+	}
 
-    @Override
-    public Header[] getRequestHeaders() {
-        return this.requestHeaders;
-    }
+	@Override
+	public void setRequestURI(URI requestURI) {
+		this.requestURI = requestURI;
+	}
 
-    @Override
-    public void setRequestURI(URI requestURI) {
-        this.requestURI = requestURI;
-    }
+	@Override
+	public void setRequestHeaders(Header[] requestHeaders) {
+		this.requestHeaders = requestHeaders;
+	}
 
-    @Override
-    public void setRequestHeaders(Header[] requestHeaders) {
-        this.requestHeaders = requestHeaders;
-    }
+	/**
+	 * Avoid leaks by using a non-anonymous handler class.
+	 */
+	private static class ResponderHandler extends Handler {
+		private final AsyncHttpResponseHandler mResponder;
 
-    /**
-     * Avoid leaks by using a non-anonymous handler class.
-     */
-    private static class ResponderHandler extends Handler {
-        private final AsyncHttpResponseHandler mResponder;
+		ResponderHandler(AsyncHttpResponseHandler mResponder, Looper looper) {
+			super(looper);
+			this.mResponder = mResponder;
+		}
 
-        ResponderHandler(AsyncHttpResponseHandler mResponder, Looper looper) {
-            super(looper);
-            this.mResponder = mResponder;
-        }
+		@Override
+		public void handleMessage(Message msg) {
+			mResponder.handleMessage(msg);
+		}
+	}
 
-        @Override
-        public void handleMessage(Message msg) {
-            mResponder.handleMessage(msg);
-        }
-    }
+	@Override
+	public boolean getUseSynchronousMode() {
+		return useSynchronousMode;
+	}
 
-    @Override
-    public boolean getUseSynchronousMode() {
-        return useSynchronousMode;
-    }
+	@Override
+	public void setUseSynchronousMode(boolean sync) {
+		// A looper must be prepared before setting asynchronous mode.
+		if (!sync && looper == null) {
+			sync = true;
+			Log.w(LOG_TAG,
+					"Current thread has not called Looper.prepare(). Forcing synchronous mode.");
+		}
 
-    @Override
-    public void setUseSynchronousMode(boolean sync) {
-        // A looper must be prepared before setting asynchronous mode.
-        if (!sync && looper == null) {
-            sync = true;
-            Log.w(LOG_TAG, "Current thread has not called Looper.prepare(). Forcing synchronous mode.");
-        }
+		// If using asynchronous mode.
+		if (!sync && handler == null) {
+			// Create a handler on current thread to submit tasks
+			handler = new ResponderHandler(this, looper);
+		} else if (sync && handler != null) {
+			// TODO: Consider adding a flag to remove all queued messages.
+			handler = null;
+		}
 
-        // If using asynchronous mode.
-        if (!sync && handler == null) {
-            // Create a handler on current thread to submit tasks
-            handler = new ResponderHandler(this, looper);
-        } else if (sync && handler != null) {
-            // TODO: Consider adding a flag to remove all queued messages.
-            handler = null;
-        }
+		useSynchronousMode = sync;
+	}
 
-        useSynchronousMode = sync;
-    }
+	@Override
+	public boolean getUsePoolThread() {
+		return usePoolThread;
+	}
 
-    @Override
-    public boolean getUsePoolThread() {
-        return usePoolThread;
-    }
+	@Override
+	public void setUsePoolThread(boolean pool) {
+		// If pool thread is to be used, there's no point in keeping a reference
+		// to the looper and no need for a handler.
+		if (pool) {
+			looper = null;
+			handler = null;
+		}
 
-    @Override
-    public void setUsePoolThread(boolean pool) {
-        // If pool thread is to be used, there's no point in keeping a reference
-        // to the looper and no need for a handler.
-        if (pool) {
-            looper = null;
-            handler = null;
-        }
+		usePoolThread = pool;
+	}
 
-        usePoolThread = pool;
-    }
+	/**
+	 * Sets the charset for the response string. If not set, the default is
+	 * UTF-8.
+	 * 
+	 * @param charset
+	 *            to be used for the response string.
+	 * @see <a
+	 *      href="http://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Charset</a>
+	 */
+	public void setCharset(final String charset) {
+		this.responseCharset = charset;
+	}
 
-    /**
-     * Sets the charset for the response string. If not set, the default is UTF-8.
-     *
-     * @param charset to be used for the response string.
-     * @see <a href="http://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html">Charset</a>
-     */
-    public void setCharset(final String charset) {
-        this.responseCharset = charset;
-    }
+	public String getCharset() {
+		return this.responseCharset == null ? DEFAULT_CHARSET
+				: this.responseCharset;
+	}
+	@Override
+	public void setOpenCache(boolean status) {
+		// TODO Auto-generated method stub
+		isCache=status;
+	}
+	@Override
+	public boolean getCacheStatus() {
+		// TODO Auto-generated method stub
+		return isCache;
+	}
+	/**
+	 * Fired when the request progress, override to handle in your own code
+	 * 
+	 * @param bytesWritten
+	 *            offset from start of file
+	 * @param totalSize
+	 *            total size of file
+	 */
+	public void onProgress(int bytesWritten, int totalSize) {
+		Log.v(LOG_TAG, String.format("Progress %d from %d (%2.0f%%)",
+				bytesWritten, totalSize,
+				(totalSize > 0) ? (bytesWritten * 1.0 / totalSize) * 100 : -1));
+	}
 
-    public String getCharset() {
-        return this.responseCharset == null ? DEFAULT_CHARSET : this.responseCharset;
-    }
+	/**
+	 * Fired when the request is started, override to handle in your own code
+	 */
+	public void onStart() {
+		// default log warning is not necessary, because this method is just
+		// optional notification
+	}
 
-    /**
-     * Fired when the request progress, override to handle in your own code
-     *
-     * @param bytesWritten offset from start of file
-     * @param totalSize    total size of file
-     */
-    public void onProgress(int bytesWritten, int totalSize) {
-        Log.v(LOG_TAG, String.format("Progress %d from %d (%2.0f%%)", bytesWritten, totalSize, (totalSize > 0) ? (bytesWritten * 1.0 / totalSize) * 100 : -1));
-    }
+	/**
+	 * Fired in all cases when the request is finished, after both success and
+	 * failure, override to handle in your own code
+	 */
+	public void onFinish() {
+		// default log warning is not necessary, because this method is just
+		// optional notification
+	}
 
-    /**
-     * Fired when the request is started, override to handle in your own code
-     */
-    public void onStart() {
-        // default log warning is not necessary, because this method is just optional notification
-    }
+	@Override
+	public void onPreProcessResponse(ResponseHandlerInterface instance,
+			HttpResponse response) {
+		// default action is to do nothing...
+	}
 
-    /**
-     * Fired in all cases when the request is finished, after both success and failure, override to
-     * handle in your own code
-     */
-    public void onFinish() {
-        // default log warning is not necessary, because this method is just optional notification
-    }
+	@Override
+	public void onPostProcessResponse(ResponseHandlerInterface instance,
+			HttpResponse response) {
+		// default action is to do nothing...
+	}
 
-    @Override
-    public void onPreProcessResponse(ResponseHandlerInterface instance, HttpResponse response) {
-        // default action is to do nothing...
-    }
+	/**
+	 * Fired when a request returns successfully, override to handle in your own
+	 * code
+	 * 
+	 * @param statusCode
+	 *            the status code of the response
+	 * @param headers
+	 *            return headers, if any
+	 * @param responseBody
+	 *            the body of the HTTP response from the server
+	 */
+	public abstract void onSuccess(int statusCode, Header[] headers,
+			byte[] responseBody);
 
-    @Override
-    public void onPostProcessResponse(ResponseHandlerInterface instance, HttpResponse response) {
-        // default action is to do nothing...
-    }
+	/**
+	 * Fired when a request fails to complete, override to handle in your own
+	 * code
+	 * 
+	 * @param statusCode
+	 *            return HTTP status code
+	 * @param headers
+	 *            return headers, if any
+	 * @param responseBody
+	 *            the response body, if any
+	 * @param error
+	 *            the underlying cause of the failure
+	 */
+	public abstract void onFailure(int statusCode, Header[] headers,
+			byte[] responseBody, Throwable error);
 
-    /**
-     * Fired when a request returns successfully, override to handle in your own code
-     *
-     * @param statusCode   the status code of the response
-     * @param headers      return headers, if any
-     * @param responseBody the body of the HTTP response from the server
-     */
-    public abstract void onSuccess(int statusCode, Header[] headers, byte[] responseBody);
+	/**
+	 * Fired when a retry occurs, override to handle in your own code
+	 * 
+	 * @param retryNo
+	 *            number of retry
+	 */
+	public void onRetry(int retryNo) {
+		Log.d(LOG_TAG, String.format("Request retry no. %d", retryNo));
+	}
 
-    /**
-     * Fired when a request fails to complete, override to handle in your own code
-     *
-     * @param statusCode   return HTTP status code
-     * @param headers      return headers, if any
-     * @param responseBody the response body, if any
-     * @param error        the underlying cause of the failure
-     */
-    public abstract void onFailure(int statusCode, Header[] headers, byte[] responseBody, Throwable error);
+	public void onCancel() {
+		Log.d(LOG_TAG, "Request got cancelled");
+	}
 
-    /**
-     * Fired when a retry occurs, override to handle in your own code
-     *
-     * @param retryNo number of retry
-     */
-    public void onRetry(int retryNo) {
-        Log.d(LOG_TAG, String.format("Request retry no. %d", retryNo));
-    }
+	@Override
+	final public void sendProgressMessage(int bytesWritten, int bytesTotal) {
+		sendMessage(obtainMessage(PROGRESS_MESSAGE, new Object[] {
+				bytesWritten, bytesTotal }));
+	}
 
-    public void onCancel() {
-        Log.d(LOG_TAG, "Request got cancelled");
-    }
+	@Override
+	final public void sendSuccessMessage(int statusCode, Header[] headers,
+			byte[] responseBytes) {
+		sendMessage(obtainMessage(SUCCESS_MESSAGE, new Object[] { statusCode,
+				headers, responseBytes }));
+	}
 
-    @Override
-    final public void sendProgressMessage(int bytesWritten, int bytesTotal) {
-        sendMessage(obtainMessage(PROGRESS_MESSAGE, new Object[]{bytesWritten, bytesTotal}));
-    }
+	@Override
+	final public void sendFailureMessage(int statusCode, Header[] headers,
+			byte[] responseBody, Throwable throwable) {
+		sendMessage(obtainMessage(FAILURE_MESSAGE, new Object[] { statusCode,
+				headers, responseBody, throwable }));
+	}
 
-    @Override
-    final public void sendSuccessMessage(int statusCode, Header[] headers, byte[] responseBytes) {
-        sendMessage(obtainMessage(SUCCESS_MESSAGE, new Object[]{statusCode, headers, responseBytes}));
-    }
+	@Override
+	final public void sendStartMessage() {
+		sendMessage(obtainMessage(START_MESSAGE, null));
+	}
 
-    @Override
-    final public void sendFailureMessage(int statusCode, Header[] headers, byte[] responseBody, Throwable throwable) {
-        sendMessage(obtainMessage(FAILURE_MESSAGE, new Object[]{statusCode, headers, responseBody, throwable}));
-    }
+	@Override
+	final public void sendFinishMessage() {
+		sendMessage(obtainMessage(FINISH_MESSAGE, null));
+	}
 
-    @Override
-    final public void sendStartMessage() {
-        sendMessage(obtainMessage(START_MESSAGE, null));
-    }
+	@Override
+	final public void sendRetryMessage(int retryNo) {
+		sendMessage(obtainMessage(RETRY_MESSAGE, new Object[] { retryNo }));
+	}
 
-    @Override
-    final public void sendFinishMessage() {
-        sendMessage(obtainMessage(FINISH_MESSAGE, null));
-    }
+	@Override
+	final public void sendCancelMessage() {
+		sendMessage(obtainMessage(CANCEL_MESSAGE, null));
+	}
 
-    @Override
-    final public void sendRetryMessage(int retryNo) {
-        sendMessage(obtainMessage(RETRY_MESSAGE, new Object[]{retryNo}));
-    }
+	// Methods which emulate android's Handler and Message methods
+	protected void handleMessage(Message message) {
+		Object[] response;
 
-    @Override
-    final public void sendCancelMessage() {
-        sendMessage(obtainMessage(CANCEL_MESSAGE, null));
-    }
+		switch (message.what) {
+		case SUCCESS_MESSAGE:
+			response = (Object[]) message.obj;
+			if (response != null && response.length >= 3) {
+				onSuccess((Integer) response[0], (Header[]) response[1],
+						(byte[]) response[2]);
+			} else {
+				Log.e(LOG_TAG, "SUCCESS_MESSAGE didn't got enough params");
+			}
+			break;
+		case FAILURE_MESSAGE:
+			response = (Object[]) message.obj;
+			if (response != null && response.length >= 4) {
+				onFailure((Integer) response[0], (Header[]) response[1],
+						(byte[]) response[2], (Throwable) response[3]);
+			} else {
+				Log.e(LOG_TAG, "FAILURE_MESSAGE didn't got enough params");
+			}
+			break;
+		case START_MESSAGE:
+			onStart();
+			break;
+		case FINISH_MESSAGE:
+			onFinish();
+			break;
+		case PROGRESS_MESSAGE:
+			response = (Object[]) message.obj;
+			if (response != null && response.length >= 2) {
+				try {
+					onProgress((Integer) response[0], (Integer) response[1]);
+				} catch (Throwable t) {
+					Log.e(LOG_TAG, "custom onProgress contains an error", t);
+				}
+			} else {
+				Log.e(LOG_TAG, "PROGRESS_MESSAGE didn't got enough params");
+			}
+			break;
+		case RETRY_MESSAGE:
+			response = (Object[]) message.obj;
+			if (response != null && response.length == 1) {
+				onRetry((Integer) response[0]);
+			} else {
+				Log.e(LOG_TAG, "RETRY_MESSAGE didn't get enough params");
+			}
+			break;
+		case CANCEL_MESSAGE:
+			onCancel();
+			break;
+		}
+	}
 
-    // Methods which emulate android's Handler and Message methods
-    protected void handleMessage(Message message) {
-        Object[] response;
+	protected void sendMessage(Message msg) {
+		if (getUseSynchronousMode() || handler == null) {
+			handleMessage(msg);
+		} else if (!Thread.currentThread().isInterrupted()) { // do not send
+																// messages if
+																// request has
+																// been
+																// cancelled
+			Utils.asserts(handler != null, "handler should not be null!");
+			handler.sendMessage(msg);
+		}
+	}
 
-        switch (message.what) {
-            case SUCCESS_MESSAGE:
-                response = (Object[]) message.obj;
-                if (response != null && response.length >= 3) {
-                    onSuccess((Integer) response[0], (Header[]) response[1], (byte[]) response[2]);
-                } else {
-                    Log.e(LOG_TAG, "SUCCESS_MESSAGE didn't got enough params");
-                }
-                break;
-            case FAILURE_MESSAGE:
-                response = (Object[]) message.obj;
-                if (response != null && response.length >= 4) {
-                    onFailure((Integer) response[0], (Header[]) response[1], (byte[]) response[2], (Throwable) response[3]);
-                } else {
-                    Log.e(LOG_TAG, "FAILURE_MESSAGE didn't got enough params");
-                }
-                break;
-            case START_MESSAGE:
-                onStart();
-                break;
-            case FINISH_MESSAGE:
-                onFinish();
-                break;
-            case PROGRESS_MESSAGE:
-                response = (Object[]) message.obj;
-                if (response != null && response.length >= 2) {
-                    try {
-                        onProgress((Integer) response[0], (Integer) response[1]);
-                    } catch (Throwable t) {
-                        Log.e(LOG_TAG, "custom onProgress contains an error", t);
-                    }
-                } else {
-                    Log.e(LOG_TAG, "PROGRESS_MESSAGE didn't got enough params");
-                }
-                break;
-            case RETRY_MESSAGE:
-                response = (Object[]) message.obj;
-                if (response != null && response.length == 1) {
-                    onRetry((Integer) response[0]);
-                } else {
-                    Log.e(LOG_TAG, "RETRY_MESSAGE didn't get enough params");
-                }
-                break;
-            case CANCEL_MESSAGE:
-                onCancel();
-                break;
-        }
-    }
+	/**
+	 * Helper method to send runnable into local handler loop
+	 * 
+	 * @param runnable
+	 *            runnable instance, can be null
+	 */
+	protected void postRunnable(Runnable runnable) {
+		if (runnable != null) {
+			if (getUseSynchronousMode() || handler == null) {
+				// This response handler is synchronous, run on current thread
+				runnable.run();
+			} else {
+				// Otherwise, run on provided handler
+				Utils.asserts(handler != null, "handler should not be null!");
+				handler.post(runnable);
+			}
+		}
+	}
 
-    protected void sendMessage(Message msg) {
-        if (getUseSynchronousMode() || handler == null) {
-            handleMessage(msg);
-        } else if (!Thread.currentThread().isInterrupted()) { // do not send messages if request has been cancelled
-            Utils.asserts(handler != null, "handler should not be null!");
-            handler.sendMessage(msg);
-        }
-    }
+	/**
+	 * Helper method to create Message instance from handler
+	 * 
+	 * @param responseMessageId
+	 *            constant to identify Handler message
+	 * @param responseMessageData
+	 *            object to be passed to message receiver
+	 * @return Message instance, should not be null
+	 */
+	protected Message obtainMessage(int responseMessageId,
+			Object responseMessageData) {
+		return Message.obtain(handler, responseMessageId, responseMessageData);
+	}
 
-    /**
-     * Helper method to send runnable into local handler loop
-     *
-     * @param runnable runnable instance, can be null
-     */
-    protected void postRunnable(Runnable runnable) {
-        if (runnable != null) {
-            if (getUseSynchronousMode() || handler == null) {
-                // This response handler is synchronous, run on current thread
-                runnable.run();
-            } else {
-                // Otherwise, run on provided handler
-                Utils.asserts(handler != null, "handler should not be null!");
-                handler.post(runnable);
-            }
-        }
-    }
+	@Override
+	public void sendResponseMessage(HttpResponse response) throws IOException {
+		// do not process if request has been cancelled
+		if (!Thread.currentThread().isInterrupted()) {
+			// response.
+			StatusLine status = response.getStatusLine();
+			byte[] responseBody;
+			Header[] head=response.getHeaders("Content-Length");
+			long serverContentSize =head.length>0?Long.valueOf(head[0].getValue()):0;
+			long serverDate=System.currentTimeMillis();
+			if (!Thread.currentThread().isInterrupted()) {
+				//判断是否开启缓存 并且检测Content-lengnth是否存在
+				if(getCacheStatus()&&serverContentSize!=0){
+					Entry entryCache = getDiskCacheData(getRequestURI().toASCIIString());
+						// 本地缓存和服务端的缓存一致并且缓存失效未过期 或者是获取网络时间的时候发生了错误也获取本地缓存
+						if (entryCache != null &&(entryCache.ttl == serverContentSize || status.getStatusCode() >= 300)) {
+							responseBody = entryCache.data;
+							AsyncHttpClient.endEntityViaReflection(response.getEntity());
+							sendSuccessMessage(status.getStatusCode(),
+									response.getAllHeaders(), responseBody);
+							return;
+						}
+						else{
+							responseBody = getResponseData(response.getEntity());
+							Entry et=new Entry();
+							et.data=responseBody;
+							et.serverDate=serverDate;
+							et.etag=""+serverDate;
+							et.ttl=serverContentSize;
+							saveCacheData(getRequestURI().getRawQuery(), et);
+							sendSuccessMessage(status.getStatusCode(),
+									response.getAllHeaders(), responseBody);							
+						}
+				}
+			
+				 else {
+					responseBody = getResponseData(response.getEntity());
+					if (status.getStatusCode() >= 300) {
+						sendFailureMessage(
+								status.getStatusCode(),
+								response.getAllHeaders(),
+								responseBody,
+								new HttpResponseException(status
+										.getStatusCode(), status
+										.getReasonPhrase()));
+					} else {
+						Entry et=new Entry();
+						et.data=responseBody;
+						et.serverDate=serverDate;
+						et.etag=""+serverDate;
+						et.ttl=serverContentSize;
+						saveCacheData(getRequestURI().toASCIIString(), et);
+						sendSuccessMessage(status.getStatusCode(),
+								response.getAllHeaders(), responseBody);
+					}
+				}
+			}
+		}
+	}
+	/**
+	 * Returns byte array of response HttpEntity contents
+	 * 
+	 * @param entity
+	 *            can be null
+	 * @return response entity body or null
+	 * @throws java.io.IOException
+	 *             if reading entity or creating byte array failed
+	 */
+	byte[] getResponseData(HttpEntity entity) throws IOException {
+		byte[] responseBody = null;
+		if (entity != null) {
+			InputStream instream = entity.getContent();
+			if (instream != null) {
+				long contentLength = entity.getContentLength();
+				if (contentLength > Integer.MAX_VALUE) {
+					throw new IllegalArgumentException(
+							"HTTP entity too large to be buffered in memory");
+				}
+				int buffersize = (contentLength <= 0) ? BUFFER_SIZE
+						: (int) contentLength;
+				try {
+					ByteArrayBuffer buffer = new ByteArrayBuffer(buffersize);
+					try {
+						byte[] tmp = new byte[BUFFER_SIZE];
+						int l, count = 0;
+						// do not send messages if request has been cancelled
+						while ((l = instream.read(tmp)) != -1
+								&& !Thread.currentThread().isInterrupted()) {
+							count += l;
+							buffer.append(tmp, 0, l);
+							sendProgressMessage(count,
+									(int) (contentLength <= 0 ? 1
+											: contentLength));
+						}
+					} finally {
+						AsyncHttpClient.silentCloseInputStream(instream);
+						AsyncHttpClient.endEntityViaReflection(entity);
+					}
 
-    /**
-     * Helper method to create Message instance from handler
-     *
-     * @param responseMessageId   constant to identify Handler message
-     * @param responseMessageData object to be passed to message receiver
-     * @return Message instance, should not be null
-     */
-    protected Message obtainMessage(int responseMessageId, Object responseMessageData) {
-        return Message.obtain(handler, responseMessageId, responseMessageData);
-    }
+					responseBody = buffer.toByteArray();
+				} catch (OutOfMemoryError e) {
+					System.gc();
+					throw new IOException(
+							"File too large to fit into available memory");
+				}
+			}
+		}
+		return responseBody;
+	}
 
-    @Override
-    public void sendResponseMessage(HttpResponse response) throws IOException {
-        // do not process if request has been cancelled
-        if (!Thread.currentThread().isInterrupted()) {
-            StatusLine status = response.getStatusLine();
-            byte[] responseBody;
-            responseBody = getResponseData(response.getEntity());
-            // additional cancellation check as getResponseData() can take non-zero time to process
-            if (!Thread.currentThread().isInterrupted()) {
-                if (status.getStatusCode() >= 300) {
-                    sendFailureMessage(status.getStatusCode(), response.getAllHeaders(), responseBody, new HttpResponseException(status.getStatusCode(), status.getReasonPhrase()));
-                } else {
-                    sendSuccessMessage(status.getStatusCode(), response.getAllHeaders(), responseBody);
-                }
-            }
-        }
-    }
+	/**
+	 * 根据指定key去缓存查找对应数据
+	 * 
+	 * @param key
+	 * @return
+	 */
+	private Entry getDiskCacheData(String key) {
+		
+		return DiskBasedCache.getCache().get(key);
 
-    /**
-     * Returns byte array of response HttpEntity contents
-     *
-     * @param entity can be null
-     * @return response entity body or null
-     * @throws java.io.IOException if reading entity or creating byte array failed
-     */
-    byte[] getResponseData(HttpEntity entity) throws IOException {
-        byte[] responseBody = null;
-        if (entity != null) {
-            InputStream instream = entity.getContent();
-            if (instream != null) {
-                long contentLength = entity.getContentLength();
-                if (contentLength > Integer.MAX_VALUE) {
-                    throw new IllegalArgumentException("HTTP entity too large to be buffered in memory");
-                }
-                int buffersize = (contentLength <= 0) ? BUFFER_SIZE : (int) contentLength;
-                try {
-                    ByteArrayBuffer buffer = new ByteArrayBuffer(buffersize);
-                    try {
-                        byte[] tmp = new byte[BUFFER_SIZE];
-                        int l, count = 0;
-                        // do not send messages if request has been cancelled
-                        while ((l = instream.read(tmp)) != -1 && !Thread.currentThread().isInterrupted()) {
-                            count += l;
-                            buffer.append(tmp, 0, l);
-                            sendProgressMessage(count, (int) (contentLength <= 0 ? 1 : contentLength));
-                        }
-                    } finally {
-                        AsyncHttpClient.silentCloseInputStream(instream);
-                        AsyncHttpClient.endEntityViaReflection(entity);
-                    }
-                    responseBody = buffer.toByteArray();
-                } catch (OutOfMemoryError e) {
-                    System.gc();
-                    throw new IOException("File too large to fit into available memory");
-                }
-            }
-        }
-        return responseBody;
-    }
+	};
+
+	private void saveCacheData(String key, Entry entry) {
+		DiskBasedCache.getCache().put(key, entry);
+	}
 }

--- a/library/src/main/java/com/loopj/android/http/Base64.java
+++ b/library/src/main/java/com/loopj/android/http/Base64.java
@@ -18,6 +18,8 @@ package com.loopj.android.http;
 
 import java.io.UnsupportedEncodingException;
 
+import com.loopj.android.http.sample.BuildConfig;
+
 /**
  * Utilities for encoding and decoding the Base64 representation of binary data.  See RFCs <a
  * href="http://www.ietf.org/rfc/rfc2045.txt">2045</a> and <a href="http://www.ietf.org/rfc/rfc3548.txt">3548</a>.

--- a/library/src/main/java/com/loopj/android/http/BinaryHttpResponseHandler.java
+++ b/library/src/main/java/com/loopj/android/http/BinaryHttpResponseHandler.java
@@ -24,6 +24,7 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.HttpUriRequest;
 
 import java.io.IOException;
 import java.util.regex.Pattern;

--- a/library/src/main/java/com/loopj/android/http/Cache.java
+++ b/library/src/main/java/com/loopj/android/http/Cache.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.loopj.android.http;
+
+
+/**
+ * An interface for a cache keyed by a String with a byte array as data.
+ */
+public interface Cache {
+    /**
+     * Retrieves an entry from the cache.
+     * @param key Cache key
+     * @return An {@link Entry} or null in the event of a cache miss
+     */
+    public Entry get(String key);
+
+    /**
+     * Adds or replaces an entry to the cache.
+     * @param key Cache key
+     * @param entry Data to store and metadata for cache coherency, TTL, etc.
+     */
+    public void put(String key, Entry entry);
+
+    /**
+     * Performs any potentially long-running actions needed to initialize the cache;
+     * will be called from a worker thread.
+     */
+    public void initialize();
+
+
+
+    /**
+     * Removes an entry from the cache.
+     * @param key Cache key
+     */
+    public void remove(String key);
+
+    /**
+     * Empties the cache.
+     */
+    public void clear();
+
+    /**
+     * Data and metadata for an entry returned by the cache.
+     */
+    public static class Entry {
+        /** The data returned from cache. */
+        public byte[] data;
+
+        /** ETag for cache coherency. */
+        public String etag;
+
+        /** Date of this response as reported by the server. */
+        public long serverDate;
+
+        /** TTL for this record. */
+        public long ttl;
+
+       
+    }
+
+}

--- a/library/src/main/java/com/loopj/android/http/DiskBasedCache.java
+++ b/library/src/main/java/com/loopj/android/http/DiskBasedCache.java
@@ -1,0 +1,598 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.loopj.android.http;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import android.os.SystemClock;
+
+/**
+ * Cache implementation that caches files directly onto the hard disk in the
+ * specified directory. The default disk usage size is 5MB, but is configurable.
+ */
+public class DiskBasedCache implements Cache {
+
+	/** Map of the Key, CacheHeader pairs */
+	private final Map<String, CacheHeader> mEntries = new LinkedHashMap<String, CacheHeader>(
+			16, .75f, true);
+
+	/** Total amount of space currently used by the cache in bytes. */
+	private long mTotalSize = 0;
+
+	/** The root directory to use for the cache. */
+	private File mRootDirectory;
+
+	/** The maximum size of the cache in bytes. */
+	private int mMaxCacheSizeInBytes;
+	/** The cache timet out day defualt 7*/
+	
+	private  int mCacheTimeOutDay=7;
+
+	/** Default maximum disk usage in bytes. */
+	private static final int DEFAULT_DISK_USAGE_BYTES = 5 * 1024 * 1024;
+
+
+	/** High water mark percentage for the cache */
+	private static final float HYSTERESIS_FACTOR = 0.9f;
+
+	/** Magic number for current version of cache file format. */
+	private static final int CACHE_MAGIC = 0x20120504;
+
+	private static DiskBasedCache diskCache;
+
+	public static DiskBasedCache init(File rootDir) {
+		if (diskCache == null) {
+			diskCache = new DiskBasedCache(rootDir);
+		}
+		return diskCache;
+
+	}
+
+	public static DiskBasedCache init(File rootDir, int maxCacheSize) {
+		if (diskCache == null) {
+			diskCache = new DiskBasedCache(rootDir, maxCacheSize);
+		}
+		return diskCache;
+	}
+
+	public static DiskBasedCache getCache() {
+		if(diskCache==null){
+			diskCache = new DiskBasedCache(new File(android.os.Environment.getExternalStorageDirectory()+"/httpCache"));
+		}
+		return diskCache;
+	}
+
+	/**
+	 * Constructs an instance of the DiskBasedCache at the specified directory.
+	 * 
+	 * @param rootDirectory
+	 *            The root directory of the cache.
+	 * @param maxCacheSizeInBytes
+	 *            The maximum size of the cache in bytes.
+	 */
+	public DiskBasedCache(File rootDirectory, int maxCacheSizeInBytes) {
+		mRootDirectory = rootDirectory;
+		mMaxCacheSizeInBytes = maxCacheSizeInBytes;
+	}
+	
+	public void setRootDir(File rootDirectory){
+		mRootDirectory = rootDirectory;
+	}
+	/**
+	 * set Cache timeout Day 
+	 * @param day
+	 */
+	public void setTimeOutDay(int day){
+		mCacheTimeOutDay=day;
+	}
+	/**
+	 * set MaxDiskCache
+	 * @param maxCacheSizeInBytes
+	 */
+	public void setMaxCache(int maxCacheSizeInBytes){
+		mMaxCacheSizeInBytes = maxCacheSizeInBytes;
+	}
+	
+	/**
+	 * Constructs an instance of the DiskBasedCache at the specified directory
+	 * using the default maximum cache size of 5MB.
+	 * 
+	 * @param rootDirectory
+	 *            The root directory of the cache.
+	 */
+	public DiskBasedCache(File rootDirectory) {
+		this(rootDirectory, DEFAULT_DISK_USAGE_BYTES);
+	}
+
+	/**
+	 * Clears the cache. Deletes all cached files from disk.
+	 */
+	@Override
+	public synchronized void clear() {
+		File[] files = mRootDirectory.listFiles();
+		if (files != null) {
+			for (File file : files) {
+				file.delete();
+			}
+		}
+		mEntries.clear();
+		mTotalSize = 0;
+	}
+
+	/**
+	 * Returns the cache entry with the specified key if it exists, null
+	 * otherwise.
+	 */
+	@Override
+	public synchronized Entry get(String key) {
+		CacheHeader entry = mEntries.get(key);
+		// if the entry does not exist, return.
+		if (entry == null) {
+			return null;
+		}
+
+		File file = getFileForKey(key);
+		CountingInputStream cis = null;
+		try {
+			cis = new CountingInputStream(new FileInputStream(file));
+			CacheHeader.readHeader(cis); // eat header
+			byte[] data = streamToBytes(cis,
+					(int) (file.length() - cis.bytesRead));
+			return entry.toCacheEntry(data);
+		} catch (IOException e) {
+			remove(key);
+			return null;
+		} finally {
+			if (cis != null) {
+				try {
+					cis.close();
+				} catch (IOException ioe) {
+					return null;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Initializes the DiskBasedCache by scanning for all files currently in the
+	 * specified root directory. Creates the root directory if necessary.
+	 */
+	@Override
+	public synchronized void initialize() {
+		if (!mRootDirectory.exists()) {
+			if (!mRootDirectory.mkdirs()) {
+			}
+			return;
+		}
+
+		File[] files = mRootDirectory.listFiles();
+		if (files == null) {
+			return;
+		}
+		for (File file : files) {
+			FileInputStream fis = null;
+			try {
+				fis = new FileInputStream(file);
+				CacheHeader entry = CacheHeader.readHeader(fis);
+				entry.size = file.length();
+				//if cache saveDate timeOut  delete
+				if ((System.currentTimeMillis() - entry.serverDate) / 86400000 > mCacheTimeOutDay) {
+					if (file != null) {
+						file.delete();
+					}
+				} else {
+					putEntry(entry.key, entry);
+				}
+			} catch (IOException e) {
+				if (file != null) {
+					file.delete();
+				}
+			} finally {
+				try {
+					if (fis != null) {
+						fis.close();
+					}
+				} catch (IOException ignored) {
+				}
+			}
+		}
+	}
+
+//	/**
+//	 * Invalidates an entry in the cache.
+//	 * 
+//	 * @param key
+//	 *            Cache key
+//	 * @param fullExpire
+//	 *            True to fully expire the entry, false to soft expire
+//	 */
+//	@Override
+//	public synchronized void invalidate(String key, boolean fullExpire) {
+//		Entry entry = get(key);
+//		if (entry != null) {
+//			entry.softTtl = 0;
+//			if (fullExpire) {
+//				entry.ttl = 0;
+//			}
+//			put(key, entry);
+//		}
+//
+//	}
+
+	/**
+	 * Puts the entry with the specified key into the cache.
+	 */
+	@Override
+	public synchronized void put(String key, Entry entry) {
+		pruneIfNeeded(entry.data.length);
+		File file = getFileForKey(key);
+		try {
+			FileOutputStream fos = new FileOutputStream(file);
+			CacheHeader e = new CacheHeader(key, entry);
+			e.writeHeader(fos);
+			fos.write(entry.data);
+			fos.close();
+			putEntry(key, e);
+			return;
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		boolean deleted = file.delete();
+		if (!deleted) {
+		}
+	}
+
+	/**
+	 * Removes the specified key from the cache if it exists.
+	 */
+	@Override
+	public synchronized void remove(String key) {
+		boolean deleted = getFileForKey(key).delete();
+		removeEntry(key);
+		if (!deleted) {
+		}
+	}
+
+	/**
+	 * Creates a pseudo-unique filename for the specified cache key.
+	 * 
+	 * @param key
+	 *            The key to generate a file name for.
+	 * @return A pseudo-unique filename.
+	 */
+	private String getFilenameForKey(String key) {
+		int firstHalfLength = key.length() / 2;
+		String localFilename = String.valueOf(key.substring(0, firstHalfLength)
+				.hashCode());
+		localFilename += String.valueOf(key.substring(firstHalfLength)
+				.hashCode());
+		return localFilename;
+	}
+
+	/**
+	 * Returns a file object for the given cache key.
+	 */
+	public File getFileForKey(String key) {
+		return new File(mRootDirectory, getFilenameForKey(key));
+	}
+
+	/**
+	 * 每次存储将会教研是否超过本地客户端设置的缓存区域大小，如果超过就删除过期的缓存
+	 * 
+	 * @param neededSpace
+	 *            The amount of bytes we are trying to fit into the cache.
+	 */
+	private void pruneIfNeeded(int neededSpace) {
+		if ((mTotalSize + neededSpace) < mMaxCacheSizeInBytes) {
+			return;
+		}
+		long before = mTotalSize;
+		int prunedFiles = 0;
+		long startTime = SystemClock.elapsedRealtime();
+
+		Iterator<Map.Entry<String, CacheHeader>> iterator = mEntries.entrySet()
+				.iterator();
+		while (iterator.hasNext()) {
+			Map.Entry<String, CacheHeader> entry = iterator.next();
+			CacheHeader e = entry.getValue();
+			boolean deleted = getFileForKey(e.key).delete();
+			if (deleted) {
+				mTotalSize -= e.size;
+			} else {
+			}
+			iterator.remove();
+			prunedFiles++;
+
+			if ((mTotalSize + neededSpace) < mMaxCacheSizeInBytes
+					* HYSTERESIS_FACTOR) {
+				break;
+			}
+		}
+
+	}
+
+	/**
+	 * Puts the entry with the specified key into the cache.
+	 * 
+	 * @param key
+	 *            The key to identify the entry by.
+	 * @param entry
+	 *            The entry to cache.
+	 */
+	private void putEntry(String key, CacheHeader entry) {
+		if (!mEntries.containsKey(key)) {
+			mTotalSize += entry.size;
+		} else {
+			CacheHeader oldEntry = mEntries.get(key);
+			mTotalSize += (entry.size - oldEntry.size);
+		}
+		mEntries.put(key, entry);
+	}
+
+	/**
+	 * Removes the entry identified by 'key' from the cache.
+	 */
+	private void removeEntry(String key) {
+		CacheHeader entry = mEntries.get(key);
+		if (entry != null) {
+			mTotalSize -= entry.size;
+			mEntries.remove(key);
+		}
+	}
+
+	/**
+	 * Reads the contents of an InputStream into a byte[].
+	 * */
+	private static byte[] streamToBytes(InputStream in, int length)
+			throws IOException {
+		byte[] bytes = new byte[length];
+		int count;
+		int pos = 0;
+		while (pos < length
+				&& ((count = in.read(bytes, pos, length - pos)) != -1)) {
+			pos += count;
+		}
+		if (pos != length) {
+			throw new IOException("Expected " + length + " bytes, read " + pos
+					+ " bytes");
+		}
+		return bytes;
+	}
+
+	/**
+	 * Handles holding onto the cache headers for an entry.
+	 */
+	// Visible for testing.
+	static class CacheHeader {
+		/**
+		 * The size of the data identified by this CacheHeader. (This is not
+		 * serialized to disk.
+		 */
+		public long size;
+
+		/** The key that identifies the cache entry. */
+		public String key;
+
+		/** ETag for cache coherence. */
+		public String etag;
+
+		/** Date of this response as reported by the server. */
+		public long serverDate;
+
+		/** TTL for this record. */
+		public long ttl;
+
+
+		/** Headers from the response resulting in this cache entry. */
+
+		private CacheHeader() {
+		}
+
+		/**
+		 * Instantiates a new CacheHeader object
+		 * 
+		 * @param key
+		 *            The key that identifies the cache entry
+		 * @param entry
+		 *            The cache entry.
+		 */
+		public CacheHeader(String key, Entry entry) {
+			this.key = key;
+			this.size = entry.data.length;
+			this.etag = entry.etag;
+			this.serverDate = entry.serverDate;
+		}
+
+		/**
+		 * Reads the header off of an InputStream and returns a CacheHeader
+		 * object.
+		 * 
+		 * @param is
+		 *            The InputStream to read from.
+		 * @throws IOException
+		 */
+		public static CacheHeader readHeader(InputStream is) throws IOException {
+			CacheHeader entry = new CacheHeader();
+			int magic = readInt(is);
+			if (magic != CACHE_MAGIC) {
+				// don't bother deleting, it'll get pruned eventually
+				throw new IOException();
+			}
+			entry.key = readString(is);
+			entry.etag = readString(is);
+			if (entry.etag.equals("")) {
+				entry.etag = null;
+			}
+			entry.serverDate = readLong(is);
+			entry.ttl = readLong(is);
+			return entry;
+		}
+
+		/**
+		 * Creates a cache entry for the specified data.
+		 */
+		public Entry toCacheEntry(byte[] data) {
+			Entry e = new Entry();
+			e.data = data;
+			e.etag = etag;
+			e.serverDate = serverDate;
+			return e;
+		}
+
+		/**
+		 * Writes the contents of this CacheHeader to the specified
+		 * OutputStream.
+		 */
+		public boolean writeHeader(OutputStream os) {
+			try {
+				writeInt(os, CACHE_MAGIC);
+				writeString(os, key);
+				writeString(os, etag == null ? "" : etag);
+				writeLong(os, serverDate);
+				writeLong(os, ttl);
+				os.flush();
+				return true;
+			} catch (IOException e) {
+				return false;
+			}
+		}
+
+	}
+
+	private static class CountingInputStream extends FilterInputStream {
+		private int bytesRead = 0;
+
+		private CountingInputStream(InputStream in) {
+			super(in);
+		}
+
+		@Override
+		public int read() throws IOException {
+			int result = super.read();
+			if (result != -1) {
+				bytesRead++;
+			}
+			return result;
+		}
+
+		@Override
+		public int read(byte[] buffer, int offset, int count)
+				throws IOException {
+			int result = super.read(buffer, offset, count);
+			if (result != -1) {
+				bytesRead += result;
+			}
+			return result;
+		}
+	}
+
+	/*
+	 * Homebrewed simple serialization system used for reading and writing cache
+	 * headers on disk. Once upon a time, this used the standard Java
+	 * Object{Input,Output}Stream, but the default implementation relies heavily
+	 * on reflection (even for standard types) and generates a ton of garbage.
+	 */
+
+	/**
+	 * Simple wrapper around {@link InputStream#read()} that throws EOFException
+	 * instead of returning -1.
+	 */
+	private static int read(InputStream is) throws IOException {
+		int b = is.read();
+		if (b == -1) {
+			throw new EOFException();
+		}
+		return b;
+	}
+
+	static void writeInt(OutputStream os, int n) throws IOException {
+		os.write((n >> 0) & 0xff);
+		os.write((n >> 8) & 0xff);
+		os.write((n >> 16) & 0xff);
+		os.write((n >> 24) & 0xff);
+	}
+
+	static int readInt(InputStream is) throws IOException {
+		int n = 0;
+		n |= (read(is) << 0);
+		n |= (read(is) << 8);
+		n |= (read(is) << 16);
+		n |= (read(is) << 24);
+		return n;
+	}
+
+	static void writeLong(OutputStream os, long n) throws IOException {
+		os.write((byte) (n >>> 0));
+		os.write((byte) (n >>> 8));
+		os.write((byte) (n >>> 16));
+		os.write((byte) (n >>> 24));
+		os.write((byte) (n >>> 32));
+		os.write((byte) (n >>> 40));
+		os.write((byte) (n >>> 48));
+		os.write((byte) (n >>> 56));
+	}
+
+	static long readLong(InputStream is) throws IOException {
+		long n = 0;
+		n |= ((read(is) & 0xFFL) << 0);
+		n |= ((read(is) & 0xFFL) << 8);
+		n |= ((read(is) & 0xFFL) << 16);
+		n |= ((read(is) & 0xFFL) << 24);
+		n |= ((read(is) & 0xFFL) << 32);
+		n |= ((read(is) & 0xFFL) << 40);
+		n |= ((read(is) & 0xFFL) << 48);
+		n |= ((read(is) & 0xFFL) << 56);
+		return n;
+	}
+
+	static void writeString(OutputStream os, String s) throws IOException {
+		byte[] b = s.getBytes("UTF-8");
+		writeLong(os, b.length);
+		os.write(b, 0, b.length);
+	}
+
+	static String readString(InputStream is) throws IOException {
+		int n = (int) readLong(is);
+		byte[] b = streamToBytes(is, n);
+		return new String(b, "UTF-8");
+	}
+
+	static void writeStringStringMap(Map<String, String> map, OutputStream os)
+			throws IOException {
+		if (map != null) {
+			writeInt(os, map.size());
+			for (Map.Entry<String, String> entry : map.entrySet()) {
+				writeString(os, entry.getKey());
+				writeString(os, entry.getValue());
+			}
+		} else {
+			writeInt(os, 0);
+		}
+	}
+
+
+}

--- a/library/src/main/java/com/loopj/android/http/JsonStreamerEntity.java
+++ b/library/src/main/java/com/loopj/android/http/JsonStreamerEntity.java
@@ -227,7 +227,7 @@ public class JsonStreamerEntity implements HttpEntity {
         os.flush();
         AsyncHttpClient.silentCloseOutputStream(os);
     }
-
+    
     private void writeToFromStream(OutputStream os, RequestParams.StreamWrapper entry)
             throws IOException {
 

--- a/library/src/main/java/com/loopj/android/http/RequestParams.java
+++ b/library/src/main/java/com/loopj/android/http/RequestParams.java
@@ -286,7 +286,7 @@ public class RequestParams implements Serializable {
         }
     }
 
-    /**
+    /**o
      * Adds param with non-string value (e.g. Map, List, Set).
      *
      * @param key   the key name for the new param.

--- a/library/src/main/java/com/loopj/android/http/ResponseHandlerInterface.java
+++ b/library/src/main/java/com/loopj/android/http/ResponseHandlerInterface.java
@@ -20,6 +20,7 @@ package com.loopj.android.http;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
 
 import java.io.IOException;
 import java.net.URI;
@@ -28,7 +29,8 @@ import java.net.URI;
  * Interface to standardize implementations
  */
 public interface ResponseHandlerInterface {
-
+	
+	
     /**
      * Returns data whether request completed successfully
      *
@@ -92,6 +94,8 @@ public interface ResponseHandlerInterface {
      * @return uri of origin request
      */
     public URI getRequestURI();
+    
+  
 
     /**
      * Returns Header[] which were used to request
@@ -113,7 +117,16 @@ public interface ResponseHandlerInterface {
      * @param requestHeaders Headers, claimed to be from original request
      */
     public void setRequestHeaders(Header[] requestHeaders);
-
+    /**
+     * settings cache is open
+     * @param status
+     */
+     void setOpenCache(boolean status);
+    /**
+     * get cache status
+     * @return
+     */
+    public boolean getCacheStatus();
     /**
      * Can set, whether the handler should be asynchronous or synchronous
      *

--- a/library/src/main/java/com/loopj/android/http/SyncHttpClient.java
+++ b/library/src/main/java/com/loopj/android/http/SyncHttpClient.java
@@ -35,8 +35,8 @@ public class SyncHttpClient extends AsyncHttpClient {
     /**
      * Creates a new SyncHttpClient with default constructor arguments values
      */
-    public SyncHttpClient() {
-        super(false, 80, 443);
+    public SyncHttpClient(Context context) {
+        super(context,false, 80, 443);
     }
 
     /**
@@ -44,8 +44,8 @@ public class SyncHttpClient extends AsyncHttpClient {
      *
      * @param httpPort non-standard HTTP-only port
      */
-    public SyncHttpClient(int httpPort) {
-        super(false, httpPort, 443);
+    public SyncHttpClient(Context context,int httpPort) {
+        super(context,false, httpPort, 443);
     }
 
     /**
@@ -54,8 +54,8 @@ public class SyncHttpClient extends AsyncHttpClient {
      * @param httpPort  non-standard HTTP-only port
      * @param httpsPort non-standard HTTPS-only port
      */
-    public SyncHttpClient(int httpPort, int httpsPort) {
-        super(false, httpPort, httpsPort);
+    public SyncHttpClient(Context context,int httpPort, int httpsPort) {
+        super(context,false, httpPort, httpsPort);
     }
 
     /**
@@ -65,8 +65,8 @@ public class SyncHttpClient extends AsyncHttpClient {
      * @param httpPort                   HTTP port to be used, must be greater than 0
      * @param httpsPort                  HTTPS port to be used, must be greater than 0
      */
-    public SyncHttpClient(boolean fixNoHttpResponseException, int httpPort, int httpsPort) {
-        super(fixNoHttpResponseException, httpPort, httpsPort);
+    public SyncHttpClient(Context context,boolean fixNoHttpResponseException, int httpPort, int httpsPort) {
+        super(context,fixNoHttpResponseException, httpPort, httpsPort);
     }
 
     /**
@@ -74,15 +74,15 @@ public class SyncHttpClient extends AsyncHttpClient {
      *
      * @param schemeRegistry SchemeRegistry to be used
      */
-    public SyncHttpClient(SchemeRegistry schemeRegistry) {
-        super(schemeRegistry);
+    public SyncHttpClient(Context context,SchemeRegistry schemeRegistry) {
+        super(context,schemeRegistry);
     }
 
     @Override
     protected RequestHandle sendRequest(DefaultHttpClient client,
                                         HttpContext httpContext, HttpUriRequest uriRequest,
                                         String contentType, ResponseHandlerInterface responseHandler,
-                                        Context context) {
+                                        Context context,boolean openCache) {
         if (contentType != null) {
             uriRequest.addHeader(AsyncHttpClient.HEADER_CONTENT_TYPE, contentType);
         }
@@ -92,7 +92,7 @@ public class SyncHttpClient extends AsyncHttpClient {
 		/*
          * will execute the request directly
 		*/
-        newAsyncHttpRequest(client, httpContext, uriRequest, contentType, responseHandler, context).run();
+        newAsyncHttpRequest(client, httpContext, uriRequest, contentType, responseHandler, context,openCache).run();
 
         // Return a Request Handle that cannot be used to cancel the request
         // because it is already complete by the time this returns


### PR DESCRIPTION
   add disk Cache.
In every time of network request will be based on the requested address URL to obtain the Content-Length parameter returns heads information to know the server returns the size of the data, to find the local disk whether there is the corresponding URL address cache, if the local cache size consistent expired and no data and server returns, do not read the network data and close request, reduce network traffic consumption. Or when the network request failure situation can also read the local cache returns data to trigger.