### PR TITLE
Feature of Support Session imported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,48 @@ Documentation, Features and Examples
 Full details and documentation can be found on the project page here:
 
 http://loopj.com/android-async-http/
+
+Recommended Usage
+------------------------------------
+
+public final class AsyncHttpUtil {
+
+	private static final AsyncHttpClient mClient = new AsyncHttpClient();
+	private static PersistentCookieStore mCookie;
+
+	private AsyncHttpUtil() {
+	}
+	
+	public static void setSessionAvailable(boolean sessionAvailable){
+	  mClient.setKeepSessionId(sessionAvailable);
+	}
+
+	public static void addCookie(Context context) {
+		mCookie = new PersistentCookieStore(context);
+		mClient.setCookieStore(mCookie);
+	}
+
+	public static void addHeader(String header, String value) {
+		mClient.addHeader(header, value);
+	}
+
+	public static RequestHandle get(String url,
+			AsyncHttpResponseHandler responseHandler) {
+		return get(url, null, responseHandler);
+	}
+
+	public static RequestHandle get(String url, RequestParams params,
+			AsyncHttpResponseHandler responseHandler) {
+		return mClient.get(url, params, responseHandler);
+	}
+
+	public static RequestHandle post(String url,
+			AsyncHttpResponseHandler responseHandler) {
+		return post(url, null, responseHandler);
+	}
+
+	public static RequestHandle post(String url, RequestParams params,
+			AsyncHttpResponseHandler responseHandler) {
+		return mClient.post(url, params, responseHandler);
+	}
+}

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ http://loopj.com/android-async-http/
 
 Recommended Usage
 ------------------------------------
+Codes Example:
 
 public final class AsyncHttpUtil {
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Recommended Usage
 Codes Example:
 
 public final class AsyncHttpUtil {
-	private static final AsyncHttpClient mClient = new AsyncHttpClient();
+private static final AsyncHttpClient mClient = new AsyncHttpClient();
 	private static PersistentCookieStore mCookie;
 
 	private AsyncHttpUtil() {

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ http://loopj.com/android-async-http/
 Recommended Usage
 ------------------------------------
 Codes Example:
-
+```
 public final class AsyncHttpUtil {
-private static final AsyncHttpClient mClient = new AsyncHttpClient();
+	private static final AsyncHttpClient mClient = new AsyncHttpClient();
 	private static PersistentCookieStore mCookie;
 
 	private AsyncHttpUtil() {
@@ -93,4 +93,5 @@ private static final AsyncHttpClient mClient = new AsyncHttpClient();
 			AsyncHttpResponseHandler responseHandler) {
 		return mClient.post(url, params, responseHandler);
 	}
-	}
+}
+```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Recommended Usage
 Codes Example:
 
 public final class AsyncHttpUtil {
-
 	private static final AsyncHttpClient mClient = new AsyncHttpClient();
 	private static PersistentCookieStore mCookie;
 
@@ -94,4 +93,4 @@ public final class AsyncHttpUtil {
 			AsyncHttpResponseHandler responseHandler) {
 		return mClient.post(url, params, responseHandler);
 	}
-}
+	}

--- a/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
@@ -113,8 +113,8 @@ public class AsyncHttpClient {
     private final Map<String, String> clientHeaderMap;
     private boolean isUrlEncodingEnabled = true;
     // Session stuff
-	private static boolean keepSessionId = false;
-	private static String sessionId;
+    private static boolean keepSessionId = false;
+    private static String sessionId;
 
     /**
      * Creates a new AsyncHttpClient with default constructor arguments values
@@ -241,8 +241,8 @@ public class AsyncHttpClient {
                     Header[] headers = response.getHeaders("Set-Cookie");
                     if (headers != null && headers.length == 1) {
                         sessionId = headers[0].getValue();
-					}
-				}
+                    }	
+                }
                 final HttpEntity entity = response.getEntity();
                 if (entity == null) {
                     return;
@@ -950,23 +950,23 @@ public class AsyncHttpClient {
     }
     
     /**
-	 * @Title: setKeepSessionId
-	 * @Description: set HttpClient communicate with server through the same session or not. By default, not.
-	 * @param keepSession
-	 * @return void
-	 */
-	public static void setKeepSessionId(boolean keepSession) {
-	    keepSessionId = keepSession;
-	}
-
-	/**
-	 * @Title: isKeepSessionId
-	 * @Description: returns boolean keepSessionId which implys whether keeps the session continueous or not.
-	 * @return boolean
-	 */
-	public static boolean isKeepSessionId() {
-	    return keepSessionId;
-	}
+     * @Title: setKeepSessionId
+     * @Description: set HttpClient communicate with server through the same session or not. By default, not.
+     * @param keepSession
+     * @return void
+     */
+     public static void setKeepSessionId(boolean keepSession) {
+     	keepSessionId = keepSession;
+     }
+     
+     /**
+      * @Title: isKeepSessionId
+      * @Description: returns boolean keepSessionId which implys whether keeps the session continueous or not.
+      * @return boolean
+      */
+      public static boolean isKeepSessionId() {
+      	return keepSessionId;
+      }
 
     /**
      * Returns HttpEntity containing data from RequestParams included with request declaration.


### PR DESCRIPTION
One option was added, which users of  'android-async-http' could select to support session or not, just by one simple line of codes. For example, AsyncHttpClient.setKeepSessionId(true/false);