### PR TITLE
Couple of fixes, one is very important:

### DIFF
--- a/library/src/main/java/com/loopj/android/http/JsonStreamerEntity.java
+++ b/library/src/main/java/com/loopj/android/http/JsonStreamerEntity.java
@@ -170,50 +170,50 @@ public class JsonStreamerEntity implements HttpEntity {
                 // Evaluate the value (which cannot be null).
                 Object value = jsonParams.get(key);
 
-                // Bail out prematurely if value's null.
-                if (value == null) {
-                    continue;
-                }
-
                 // Write the JSON object's key.
                 os.write(escape(key));
                 os.write(':');
 
-                // Check if this is a FileWrapper.
-                isFileWrapper = value instanceof RequestParams.FileWrapper;
-
-                // If a file should be uploaded.
-                if (isFileWrapper || value instanceof RequestParams.StreamWrapper) {
-                    // All uploads are sent as an object containing the file's details.
-                    os.write('{');
-
-                    // Determine how to handle this entry.
-                    if (isFileWrapper) {
-                        writeToFromFile(os, (RequestParams.FileWrapper) value);
-                    } else {
-                        writeToFromStream(os, (RequestParams.StreamWrapper) value);
-                    }
-
-                    // End the file's object and prepare for next one.
-                    os.write('}');
-                } else if (value instanceof JsonValueInterface) {
-                    os.write(((JsonValueInterface) value).getEscapedJsonValue());
-                } else if (value instanceof org.json.JSONObject) {
-                    os.write(((org.json.JSONObject) value).toString().getBytes());
-                } else if (value instanceof org.json.JSONArray) {
-                    os.write(((org.json.JSONArray) value).toString().getBytes());
-                } else if (value instanceof Boolean) {
-                    os.write((Boolean) value ? JSON_TRUE : JSON_FALSE);
-                } else if (value instanceof Long) {
-                    os.write((((Number) value).longValue() + "").getBytes());
-                } else if (value instanceof Double) {
-                    os.write((((Number) value).doubleValue() + "").getBytes());
-                } else if (value instanceof Float) {
-                    os.write((((Number) value).floatValue() + "").getBytes());
-                } else if (value instanceof Integer) {
-                    os.write((((Number) value).intValue() + "").getBytes());
+                // Bail out prematurely if value's null.
+                if (value == null) {
+                    os.write(JSON_NULL);
                 } else {
-                    os.write(escape(value.toString()));
+                    // Check if this is a FileWrapper.
+                    isFileWrapper = value instanceof RequestParams.FileWrapper;
+
+                    // If a file should be uploaded.
+                    if (isFileWrapper || value instanceof RequestParams.StreamWrapper) {
+                        // All uploads are sent as an object containing the file's details.
+                        os.write('{');
+
+                        // Determine how to handle this entry.
+                        if (isFileWrapper) {
+                            writeToFromFile(os, (RequestParams.FileWrapper) value);
+                        } else {
+                            writeToFromStream(os, (RequestParams.StreamWrapper) value);
+                        }
+
+                        // End the file's object and prepare for next one.
+                        os.write('}');
+                    } else if (value instanceof JsonValueInterface) {
+                        os.write(((JsonValueInterface) value).getEscapedJsonValue());
+                    } else if (value instanceof org.json.JSONObject) {
+                        os.write(((org.json.JSONObject) value).toString().getBytes());
+                    } else if (value instanceof org.json.JSONArray) {
+                        os.write(((org.json.JSONArray) value).toString().getBytes());
+                    } else if (value instanceof Boolean) {
+                        os.write((Boolean) value ? JSON_TRUE : JSON_FALSE);
+                    } else if (value instanceof Long) {
+                        os.write((((Number) value).longValue() + "").getBytes());
+                    } else if (value instanceof Double) {
+                        os.write((((Number) value).doubleValue() + "").getBytes());
+                    } else if (value instanceof Float) {
+                        os.write((((Number) value).floatValue() + "").getBytes());
+                    } else if (value instanceof Integer) {
+                        os.write((((Number) value).intValue() + "").getBytes());
+                    } else {
+                        os.write(escape(value.toString()));
+                    }
                 }
             } finally {
                 // Separate each K:V with a comma, except the last one.

--- a/library/src/main/java/com/loopj/android/http/RequestParams.java
+++ b/library/src/main/java/com/loopj/android/http/RequestParams.java
@@ -99,6 +99,7 @@ public class RequestParams implements Serializable {
     protected final static String LOG_TAG = "RequestParams";
     protected boolean isRepeatable;
     protected boolean useJsonStreamer;
+    protected String elapsedFieldInJsonStreamer = "_elapsed";
     protected boolean autoCloseInputStreams;
     protected final ConcurrentHashMap<String, String> urlParams = new ConcurrentHashMap<String, String>();
     protected final ConcurrentHashMap<String, StreamWrapper> streamParams = new ConcurrentHashMap<String, StreamWrapper>();
@@ -412,12 +413,25 @@ public class RequestParams implements Serializable {
         return result.toString();
     }
 
-    public void setHttpEntityIsRepeatable(boolean isRepeatable) {
-        this.isRepeatable = isRepeatable;
+    public void setHttpEntityIsRepeatable(boolean flag) {
+        this.isRepeatable = flag;
     }
 
-    public void setUseJsonStreamer(boolean useJsonStreamer) {
-        this.useJsonStreamer = useJsonStreamer;
+    public void setUseJsonStreamer(boolean flag) {
+        this.useJsonStreamer = flag;
+    }
+
+    /**
+     * Sets an additional field when upload a JSON object through the streamer
+     * to hold the time, in milliseconds, it took to upload the payload. By
+     * default, this field is set to "_elapsed".
+     *
+     * To disable this feature, call this method with null as the field value.
+     *
+     * @param value field name to add elapsed time, or null to disable
+     */
+    public void setElapsedFieldInJsonStreamer(String value) {
+        this.elapsedFieldInJsonStreamer = value;
     }
 
     /**
@@ -449,8 +463,10 @@ public class RequestParams implements Serializable {
     }
 
     private HttpEntity createJsonStreamerEntity(ResponseHandlerInterface progressHandler) throws IOException {
-        JsonStreamerEntity entity = new JsonStreamerEntity(progressHandler,
-                !fileParams.isEmpty() || !streamParams.isEmpty());
+        JsonStreamerEntity entity = new JsonStreamerEntity(
+            progressHandler,
+            !fileParams.isEmpty() || !streamParams.isEmpty(),
+            elapsedFieldInJsonStreamer);
 
         // Add string params
         for (ConcurrentHashMap.Entry<String, String> entry : urlParams.entrySet()) {


### PR DESCRIPTION
1) When uploading many requests using JSON streamer, the reusable StringBuffer would have been emptied; a fix is now enclosed

2) Added a feature request: Let the user decide whether to embed "_elapsed" field, and even customize its name, or disable it completely.