### PR TITLE
Wrap callback handlers in try-catch to block retries.

### DIFF
--- a/library/src/main/java/com/loopj/android/http/AsyncHttpRequest.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpRequest.java
@@ -152,21 +152,33 @@ public class AsyncHttpRequest implements Runnable {
         }
 
         // Carry out pre-processing for this response.
-        responseHandler.onPreProcessResponse(responseHandler, response);
+        try {
+          responseHandler.onPreProcessResponse(responseHandler, response);
+        } catch(Throwable error) {
+          reportUserCodeError("onPreProcessResponse", error);
+        }
 
         if (isCancelled()) {
             return;
         }
 
         // The response is ready, handle it.
-        responseHandler.sendResponseMessage(response);
+        try {
+          responseHandler.sendResponseMessage(response);
+        } catch(Throwable error) {
+          reportUserCodeError("sendResponseMessage", error);
+        }
 
         if (isCancelled()) {
             return;
         }
 
         // Carry out post-processing for this response.
-        responseHandler.onPostProcessResponse(responseHandler, response);
+        try {
+          responseHandler.onPostProcessResponse(responseHandler, response);
+        } catch(Throwable error) {
+          reportUserCodeError("onPostProcessResponse", error);
+        }
     }
 
     private void makeRequestWithRetries() throws IOException {
@@ -210,6 +222,16 @@ public class AsyncHttpRequest implements Runnable {
 
         // cleaned up to throw IOException
         throw (cause);
+    }
+
+    private void reportUserCodeError(String where, Throwable error) {
+        Log.e(
+            "AsyncHttpRequest",
+            "Unhandled exception in user code while processing '" +
+                where +
+            "' handler",
+            error
+        );
     }
 
     public boolean isCancelled() {


### PR DESCRIPTION
This is a special case scenario where the user's code is buggy and throws exceptions. In this scenario, and even if the response has already been received, the retry handler will erroneously try again to connect and process the same request, which is wrong.