### PR TITLE
updated JsonHttpResponseHandler.java to handle string, numeric, boolean ...

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 02 18:01:59 CEST 2014
+#Thu Jan 22 17:47:44 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/library/src/main/java/com/loopj/android/http/JsonHttpResponseHandler.java
+++ b/library/src/main/java/com/loopj/android/http/JsonHttpResponseHandler.java
@@ -39,6 +39,9 @@ public class JsonHttpResponseHandler extends TextHttpResponseHandler {
 
     private static final String LOG_TAG = "JsonHttpResponseHandler";
 
+
+    private boolean useRFC5179CompatibilityMode = true;
+
     /**
      * Creates new JsonHttpResponseHandler, with JSON String encoding UTF-8
      */
@@ -47,12 +50,33 @@ public class JsonHttpResponseHandler extends TextHttpResponseHandler {
     }
 
     /**
-     * Creates new JsonHttpRespnseHandler with given JSON String encoding
+     * Creates new JsonHttpResponseHandler with given JSON String encoding
      *
      * @param encoding String encoding to be used when parsing JSON
      */
     public JsonHttpResponseHandler(String encoding) {
         super(encoding);
+    }
+
+    /**
+     * Creates new JsonHttpResponseHandler with JSON String encoding UTF-8 and given RFC5179CompatibilityMode
+     *
+     * @param useRFC5179CompatibilityMode Boolean mode to use RFC5179 or latest
+     */
+    public JsonHttpResponseHandler(boolean useRFC5179CompatibilityMode) {
+        super(DEFAULT_CHARSET);
+        this.useRFC5179CompatibilityMode = useRFC5179CompatibilityMode;
+    }
+
+    /**
+     * Creates new JsonHttpResponseHandler with given JSON String encoding and RFC5179CompatibilityMode
+     *
+     * @param encoding String encoding to be used when parsing JSON
+     * @param useRFC5179CompatibilityMode Boolean mode to use RFC5179 or latest
+     */
+    public JsonHttpResponseHandler(String encoding, boolean useRFC5179CompatibilityMode) {
+        super(encoding);
+        this.useRFC5179CompatibilityMode = useRFC5179CompatibilityMode;
     }
 
     /**
@@ -122,14 +146,20 @@ public class JsonHttpResponseHandler extends TextHttpResponseHandler {
                         postRunnable(new Runnable() {
                             @Override
                             public void run() {
-                                if(jsonResponse == null){
+                                // In RFC5179 a null value is not a valid JSON
+                                if(!useRFC5179CompatibilityMode && jsonResponse == null){
                                     onSuccess(statusCode, headers, (String) jsonResponse);
                                 }else if (jsonResponse instanceof JSONObject) {
                                     onSuccess(statusCode, headers, (JSONObject) jsonResponse);
                                 } else if (jsonResponse instanceof JSONArray) {
                                     onSuccess(statusCode, headers, (JSONArray) jsonResponse);
                                 } else if (jsonResponse instanceof String) {
-                                    onSuccess(statusCode, headers, (String) jsonResponse);
+                                    // In RFC5179 a simple string value is not a valid JSON
+                                    if ( useRFC5179CompatibilityMode){
+                                        onFailure(statusCode, headers, (String) jsonResponse, new JSONException("Response cannot be parsed as JSON data"));
+                                    }else{
+                                        onSuccess(statusCode, headers, (String) jsonResponse);
+                                    }
                                 } else {
                                     onFailure(statusCode, headers, new JSONException("Unexpected response type " + jsonResponse.getClass().getName()), (JSONObject) null);
                                 }
@@ -167,7 +197,8 @@ public class JsonHttpResponseHandler extends TextHttpResponseHandler {
                         postRunnable(new Runnable() {
                             @Override
                             public void run() {
-                                if (jsonResponse == null){
+                                // In RFC5179 a null value is not a valid JSON
+                                if (!useRFC5179CompatibilityMode && jsonResponse == null){
                                     onFailure(statusCode, headers, (String) jsonResponse, throwable);
                                 }else if (jsonResponse instanceof JSONObject) {
                                     onFailure(statusCode, headers, throwable, (JSONObject) jsonResponse);
@@ -223,20 +254,36 @@ public class JsonHttpResponseHandler extends TextHttpResponseHandler {
             if (jsonString.startsWith(UTF8_BOM)) {
                 jsonString = jsonString.substring(1);
             }
-            // Check if the string is an JSONObject style {} or JSONArray style []
-            // If not we consider this as a string
-            if (( jsonString.startsWith("{") && jsonString.endsWith("}") )
-                    || jsonString.startsWith("[") && jsonString.endsWith("]") ) {
-                result = new JSONTokener(jsonString).nextValue();
-                return result;
-            }
-            // Check if this is a String "my String value" and remove quote
-            // Other value type (numerical, boolean) should be without quote
-            else if ( jsonString.startsWith("\"") && jsonString.endsWith("\"") ){
-                result = jsonString.substring(1,jsonString.length()-1);
-                return result;
+            if ( useRFC5179CompatibilityMode){
+                if (jsonString.startsWith("{") || jsonString.startsWith("[")) {
+                    result = new JSONTokener(jsonString).nextValue();
+                }
+            }else{
+                // Check if the string is an JSONObject style {} or JSONArray style []
+                // If not we consider this as a string
+                if (( jsonString.startsWith("{") && jsonString.endsWith("}") )
+                        || jsonString.startsWith("[") && jsonString.endsWith("]") ) {
+                    result = new JSONTokener(jsonString).nextValue();
+                }
+                // Check if this is a String "my String value" and remove quote
+                // Other value type (numerical, boolean) should be without quote
+                else if ( jsonString.startsWith("\"") && jsonString.endsWith("\"") ){
+                    result = jsonString.substring(1,jsonString.length()-1);
+                }
             }
         }
-        return jsonString;
+        if (result == null) {
+            result = jsonString;
+        }
+        return result;
     }
+
+    public boolean isUseRFC5179CompatibilityMode() {
+        return useRFC5179CompatibilityMode;
+    }
+
+    public void setUseRFC5179CompatibilityMode(boolean useRFC5179CompatibilityMode) {
+        this.useRFC5179CompatibilityMode = useRFC5179CompatibilityMode;
+    }
+
 }


### PR DESCRIPTION
...and null value

issue : #787 

I updated the parseResponse function because string with only one opened brace or bracket was parsed into JSONObject or JSONArray, which was not good.

I was thinking about making a JSONSimpleValue class which can handle simple string, boolean, numerical and null value, and check if value is a string, numerical, boolean or null value. And of course a callback with this type.

This could be better than let user do these things. I don't know what you think about that.
