### PR TITLE
Added constructor that also takes a looper

### DIFF
--- a/library/src/main/java/com/loopj/android/http/BinaryHttpResponseHandler.java
+++ b/library/src/main/java/com/loopj/android/http/BinaryHttpResponseHandler.java
@@ -18,6 +18,7 @@
 
 package com.loopj.android.http;
 
+import android.os.Looper;
 import android.util.Log;
 
 import org.apache.http.Header;
@@ -85,6 +86,22 @@ public abstract class BinaryHttpResponseHandler extends AsyncHttpResponseHandler
      */
     public BinaryHttpResponseHandler(String[] allowedContentTypes) {
         super();
+        if (allowedContentTypes != null) {
+            mAllowedContentTypes = allowedContentTypes;
+        } else {
+            Log.e(LOG_TAG, "Constructor passed allowedContentTypes was null !");
+        }
+    }
+    
+    /**
+     * Creates a new BinaryHttpResponseHandler with a user-supplied looper, and overrides the default allowed content types with
+     * passed String array (hopefully) of content types.
+     *
+     * @param allowedContentTypes content types array, eg. 'image/jpeg' or pattern '.*'
+     * @param looper The looper to work with
+     */
+    public BinaryHttpResponseHandler(String[] allowedContentTypes, Looper looper) {
+        super(looper);
         if (allowedContentTypes != null) {
             mAllowedContentTypes = allowedContentTypes;
         } else {


### PR DESCRIPTION
Not sure if this is useful to others or not.  I wanted to download resources (fonts, overlays, etc) in the background and cache them.  This change allowed me to use the binary response handler so I could set allowed content types. and also specify a looper for downloading.