### PR TITLE
Fix ConcurrentModificationException when accessing request list

### DIFF
--- a/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
+++ b/library/src/main/java/com/loopj/android/http/AsyncHttpClient.java
@@ -938,8 +938,10 @@ public class AsyncHttpClient {
 
     private void cancelRequests(final List<RequestHandle> requestList, final boolean mayInterruptIfRunning) {
         if (requestList != null) {
-            for (RequestHandle requestHandle : requestList) {
-                requestHandle.cancel(mayInterruptIfRunning);
+            synchronized (requestList) {
+                for (RequestHandle requestHandle : requestList) {
+                    requestHandle.cancel(mayInterruptIfRunning);
+                }
             }
         }
     }
@@ -956,8 +958,10 @@ public class AsyncHttpClient {
     public void cancelAllRequests(boolean mayInterruptIfRunning) {
         for (List<RequestHandle> requestList : requestMap.values()) {
             if (requestList != null) {
-                for (RequestHandle requestHandle : requestList) {
-                    requestHandle.cancel(mayInterruptIfRunning);
+                synchronized (requestList) {
+                    for (RequestHandle requestHandle : requestList) {
+                        requestHandle.cancel(mayInterruptIfRunning);
+                    }
                 }
             }
         }
@@ -980,9 +984,11 @@ public class AsyncHttpClient {
         }
         for (List<RequestHandle> requestList : requestMap.values()) {
             if (requestList != null) {
-                for (RequestHandle requestHandle : requestList) {
-                    if (TAG.equals(requestHandle.getTag()))
-                        requestHandle.cancel(mayInterruptIfRunning);
+                synchronized (requestList) {
+                    for (RequestHandle requestHandle : requestList) {
+                        if (TAG.equals(requestHandle.getTag()))
+                            requestHandle.cancel(mayInterruptIfRunning);
+                    }
                 }
             }
         }
@@ -1572,10 +1578,12 @@ public class AsyncHttpClient {
 
             requestList.add(requestHandle);
 
-            Iterator<RequestHandle> iterator = requestList.iterator();
-            while (iterator.hasNext()) {
-                if (iterator.next().shouldBeGarbageCollected()) {
-                    iterator.remove();
+            synchronized (requestList) {
+                Iterator<RequestHandle> iterator = requestList.iterator();
+                while (iterator.hasNext()) {
+                    if (iterator.next().shouldBeGarbageCollected()) {
+                        iterator.remove();
+                    }
                 }
             }
         }


### PR DESCRIPTION
If I send several requests from different threads with same context,
the request list iteration and modification may happen at the same
time, which will throw ConcurrentModificationException.

Since request list is a synchronizedList, Just wrap loops in
synchronized blocks.

This is part of my crash report(v1.4.9)

```
java.util.ConcurrentModificationException
    at java.util.LinkedList$LinkIterator.next(LinkedList.java:124)
    at com.loopj.android.http.AsyncHttpClient.sendRequest(AsyncHttpClient.java:1526)
    at com.loopj.android.http.AsyncHttpClient.get(AsyncHttpClient.java:1095)
        at .....
```
